### PR TITLE
Use `oc wait` to wait for condition instead of running oc commands

### DIFF
--- a/07_deploy_masters.sh
+++ b/07_deploy_masters.sh
@@ -71,10 +71,7 @@ for i in $(seq 0 2); do
   oc --config ocp/auth/kubeconfig wait nodes/master-$i --for condition=ready --timeout=600s
 done
 
-# Wait for bootstrap to complete
-while ! oc --config ocp/auth/kubeconfig get events -n kube-system --no-headers -o wide | grep -q bootstrap-complete; do
-  sleep 10
-done
+wait_for_bootstrap_event
 
 # disable NoSchedule taints for masters until we have workers deployed
 for num in 0 1 2; do

--- a/07_deploy_masters.sh
+++ b/07_deploy_masters.sh
@@ -58,15 +58,20 @@ done
 echo "Master nodes up, you can ssh to the following IPs with core@<IP>"
 sudo virsh net-dhcp-leases baremetal
 
-while [[ ! $(timeout -k 9 5 $SSH "core@api.${CLUSTER_NAME}.${BASE_DOMAIN}" hostname) =~ master- ]]; do
-  echo "Waiting for the master API to become ready..."
+# Wait for nodes to appear and become ready
+until oc --config ocp/auth/kubeconfig get nodes; do sleep 5; done
+NUM_NODES=$(oc --config ocp/auth/kubeconfig get nodes --no-headers | wc -l)
+while [ "$NUM_NODES" -ne 3 ]; do
   sleep 10
+  NUM_NODES=$(oc --config ocp/auth/kubeconfig get nodes --no-headers | wc -l)
+done
+for i in $(seq 0 2); do
+  oc --config ocp/auth/kubeconfig wait nodes/master-$i --for condition=ready --timeout=600s
 done
 
-NODES_ACTIVE=$(oc --config ocp/auth/kubeconfig get nodes | grep "master-[0-2] *Ready" | wc -l)
-while [ "$NODES_ACTIVE" -ne 3 ]; do
+# Wait for bootstrap to complete
+while ! oc --config ocp/auth/kubeconfig get events -n kube-system --no-headers -o wide | grep -q bootstrap-complete; do
   sleep 10
-  NODES_ACTIVE=$(oc --config ocp/auth/kubeconfig get nodes | grep "master-[0-2] *Ready" | wc -l)
 done
 
 # disable NoSchedule taints for masters until we have workers deployed
@@ -74,5 +79,4 @@ for num in 0 1 2; do
   oc --kubeconfig ocp/auth/kubeconfig adm taint nodes master-${num} node-role.kubernetes.io/master:NoSchedule-
 done
 
-oc --config ocp/auth/kubeconfig get nodes
 echo "Cluster up, you can interact with it via oc --config ocp/auth/kubeconfig <command>"

--- a/07_deploy_masters.sh
+++ b/07_deploy_masters.sh
@@ -10,6 +10,8 @@ source ocp_install_env.sh
 export OS_TOKEN=fake-token
 export OS_URL=http://localhost:6385/
 
+trap collect_info_on_failure TERM
+
 wait_for_json ironic \
     "${OS_URL}/v1/nodes" \
     10 \

--- a/utils.sh
+++ b/utils.sh
@@ -188,3 +188,10 @@ resource "ironic_node_v1" "openshift-master-${master_idx}" {
 }
 EOF
 }
+
+function collect_info_on_failure() {
+    $SSH -o ConnectionAttempts=500 core@$IP sudo journalctl -b -u bootkube
+    oc --kubeconfig ocp/auth/kubeconfig get clusterversion/version
+    oc --kubeconfig ocp/auth/kubeconfig get clusteroperators
+    oc --kubeconfig ocp/auth/kubeconfig get pods --all-namespaces | grep -v Running | grep -v Completed
+}

--- a/utils.sh
+++ b/utils.sh
@@ -195,3 +195,20 @@ function collect_info_on_failure() {
     oc --kubeconfig ocp/auth/kubeconfig get clusteroperators
     oc --kubeconfig ocp/auth/kubeconfig get pods --all-namespaces | grep -v Running | grep -v Completed
 }
+
+function wait_for_bootstrap_event() {
+  local events
+  local counter
+  pause=10
+  max_attempts=60 # 60*10 = at least 10 mins of attempts
+
+  for i in $(seq 0 "$max_attempts"); do
+    events=$(oc --request-timeout=5s --config ocp/auth/kubeconfig get events -n kube-system --no-headers -o wide)
+    echo "$events"
+    if [[ ! $events =~ "bootstrap-complete" ]]; then 
+      sleep "$pause";
+    else
+      break
+    fi
+  done
+}


### PR DESCRIPTION
There is no need to repeat oc commands - it has `oc wait` subcommands which pauses until a particular `.status.condition` is set to True.

There is no `oc wait` for events, so this would run `oc get events` in a loop and look for `bootstrap-complete` event instead. Loop is limited to 60 attempts with 10 sec pause so bootstrapping is expected to complete in 10+ minutes.

If the cluster didn't start the script would output:
1. bootstrap.service logs
2. clusterversion operator status
3. operator status
4. List of failing pods