### PR TITLE
Use terraform to install the masters

### DIFF
--- a/01_install_requirements.sh
+++ b/01_install_requirements.sh
@@ -93,6 +93,14 @@ if [ ! -f ${oc_tools_dir}/${oc_tools_local_file} ]; then
   sudo cp oc /usr/local/bin/
 fi
 
+# Install terraform
+if [ ! -f /usr/local/bin/terraform ]; then
+    curl -O https://releases.hashicorp.com/terraform/0.11.11/terraform_0.11.11_linux_amd64.zip
+    unzip terraform_0.11.11_linux_amd64.zip
+    sudo install terraform /usr/local/bin
+    rm -f terraform_0.11.11_linux_amd64.zip terraform
+fi
+
 # Generate user ssh key
 if [ ! -f $HOME/.ssh/id_rsa.pub ]; then
     ssh-keygen -f ~/.ssh/id_rsa -P ""

--- a/03_ocp_repo_sync.sh
+++ b/03_ocp_repo_sync.sh
@@ -32,6 +32,8 @@ function sync_go_repo_and_patch {
 
 sync_go_repo_and_patch github.com/openshift-metalkube/kni-installer https://github.com/openshift-metalkube/kni-installer.git
 
+sync_go_repo_and_patch github.com/openshift-metalkube/terraform-provider-ironic https://github.com/openshift-metalkube/terraform-provider-ironic.git
+
 sync_go_repo_and_patch github.com/openshift-metalkube/facet https://github.com/openshift-metalkube/facet.git
 
 # Build facet

--- a/05_build_ocp_installer.sh
+++ b/05_build_ocp_installer.sh
@@ -14,3 +14,7 @@ export MODE=release
 export TAGS=libvirt
 ./hack/build.sh
 popd
+
+pushd "$GOPATH/src/github.com/openshift-metalkube/terraform-provider-ironic"
+make install
+popd

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,10 @@ ocp_run:
 	./06_deploy_bootstrap_vm.sh
 	./07_deploy_masters.sh
 
-clean: ocp_cleanup host_cleanup
+clean: masters_cleanup ocp_cleanup host_cleanup
+
+masters_cleanup:
+	./masters_cleanup.sh
 
 ocp_cleanup:
 	./ocp_cleanup.sh

--- a/masters_cleanup.sh
+++ b/masters_cleanup.sh
@@ -1,20 +1,9 @@
 #!/usr/bin/bash
 
 set -eux
-source utils.sh
-source common.sh
-source ocp_install_env.sh
 
-export OS_TOKEN=fake-token
-export OS_URL=http://localhost:6385/
-
-# FIXME: this should just be "terraform delete"
-nodes=$(openstack baremetal node list)
-for node in $(jq -r .nodes[].name ${MASTER_NODES_FILE}); do
-  if [[ $nodes =~ $node ]]; then
-    openstack baremetal node undeploy $node --wait || true
-    openstack baremetal node delete $node
-  fi
-done
-
+pushd ocp/tf-master
+terraform init  # in case plugin has changed
+terraform destroy --auto-approve
+popd
 rm -rf ocp/tf-master

--- a/masters_cleanup.sh
+++ b/masters_cleanup.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/bash
+
+set -eux
+source utils.sh
+source common.sh
+source ocp_install_env.sh
+
+export OS_TOKEN=fake-token
+export OS_URL=http://localhost:6385/
+
+# FIXME: this should just be "terraform delete"
+nodes=$(openstack baremetal node list)
+for node in $(jq -r .nodes[].name ${MASTER_NODES_FILE}); do
+  if [[ $nodes =~ $node ]]; then
+    openstack baremetal node undeploy $node --wait || true
+    openstack baremetal node delete $node
+  fi
+done
+
+rm -rf ocp/tf-master


### PR DESCRIPTION
Install terraform and terraform-provider-ironic. Add a script that you can use to experiment with using terraform to deploy the masters after 07_deploy_masters.sh exits early.

This uses the unmerged code in metalkube/terraform-provider-ironic#2

---

TODO list before merging:

- [x] - Merge metalkube/terraform-provider-ironic#2
- [x] - Implement "destroy" in terraform-provider-ironic
- [x] - Fix how terraform-provider-ironic is built, including pulling in latest gophercloud/utils
- [x] - Use "terraform destroy" in masters_cleanup.sh