### PR TITLE
Removing the bootstrap VM as part of cleanup

### DIFF
--- a/host_cleanup.sh
+++ b/host_cleanup.sh
@@ -24,6 +24,16 @@ ANSIBLE_FORCE_COLOR=true ansible-playbook \
     -b -vvv tripleo-quickstart-config/metalkube-teardown-playbook.yml
 
 sudo rm -rf /etc/NetworkManager/dnsmasq.d/openshift.conf /etc/NetworkManager/conf.d/dnsmasq.conf
+
+#Remove the bootstrap VM
+sudo virsh list --all --name|grep -q bootstrap && (
+    for i in $(sudo virsh list --all --name|grep bootstrap); do
+          sudo virsh destroy $i 2>/dev/null;
+          sudo virsh undefine $i 2>/dev/null;
+    done
+)
+
+#Remove the networks
 sudo virsh net-destroy baremetal
 sudo virsh net-undefine baremetal
 sudo virsh net-destroy provisioning


### PR DESCRIPTION
The bootstap VM was remaining after 'make clean'.
This patch deals with its removal.

Signed-off-by: Alexander Chuzhoy <achuzhoy@redhat.com>