### PR TITLE
 Remove if-name for etc discovery

### DIFF
--- a/06_deploy_bootstrap_vm.sh
+++ b/06_deploy_bootstrap_vm.sh
@@ -41,9 +41,6 @@ $SSH -o ConnectionAttempts=500 core@$IP id
 # Create a master_nodes.json file
 jq '.nodes[0:3] | {nodes: .}' "${NODES_FILE}" | tee "${MASTER_NODES_FILE}"
 
-# Fix etcd discovery on bootstrap
-add_if_name_to_etcd_discovery "$IP" "eth1"
-
 # Generate "dynamic" ignition patches
 machineconfig_generate_patches "master"
 # Apply patches to masters


### PR DESCRIPTION
The if-name for etc discovery is no longer required because of:

https://github.com/openshift/machine-config-operator/pull/547
