### PR TITLE
keepalived: prepare for multiple VIPs

### DIFF
--- a/machineconfig/master/spec/config/storage/files/check_ocp_api.sh L2V0Yy9rZWVwYWxpdmVkL2NoZWNrX29jcF9hcGkuc2gK
+++ b/machineconfig/master/spec/config/storage/files/check_ocp_api.sh L2V0Yy9rZWVwYWxpdmVkL2NoZWNrX29jcF9hcGkuc2gK
@@ -1,1 +1,0 @@
-exec curl -o /dev/null -kLs "https://0:6443/healthz"

--- a/machineconfig/master/spec/config/storage/files/keepalived.conf.template L2V0Yy9rZWVwYWxpdmVkL2tlZXBhbGl2ZWQuY29uZi50ZW1wbGF0ZQo=
+++ b/machineconfig/master/spec/config/storage/files/keepalived.conf.template L2V0Yy9rZWVwYWxpdmVkL2tlZXBhbGl2ZWQuY29uZi50ZW1wbGF0ZQo=
@@ -1,9 +1,9 @@
 vrrp_script chk_ocp {
-    script "/etc/keepalived/check_ocp_api.sh"
+    script "curl -o /dev/null -kLs https://0:6443/healthz"
     interval 1
     weight 50
 }
-vrrp_instance VI_1 {
+vrrp_instance API {
     state BACKUP
     interface ${INTERFACE}
     virtual_router_id 51
@@ -11,7 +11,7 @@ vrrp_instance VI_1 {
     advert_int 1
     authentication {
         auth_type PASS
-        auth_pass cluster_uuid_master_vip
+        auth_pass cluster_uuid_api_vip
     }
     virtual_ipaddress {
         ${API_VIP}

--- a/machineconfig/master/spec/config/storage/files/keepalived.sh L3Vzci9sb2NhbC9iaW4va2VlcGFsaXZlZC5zaAo=
+++ b/machineconfig/master/spec/config/storage/files/keepalived.sh L3Vzci9sb2NhbC9iaW4va2VlcGFsaXZlZC5zaAo=
@@ -40,23 +40,25 @@ EOF
 
 mkdir --parents /etc/keepalived
 
-KEEPALIVED_IMAGE=registry.access.redhat.com/rhosp14/openstack-keepalived:14.0
+KEEPALIVED_IMAGE="quay.io/celebdor/keepalived:latest"
 if ! podman inspect "$KEEPALIVED_IMAGE" &>/dev/null; then
     echo "Pulling release image..."
     podman pull "$KEEPALIVED_IMAGE"
 fi
 
-export INTERFACE="$(get_iface_in_vip_subnet "$API_VIP")"
-export API_VIP="$API_VIP"
+INTERFACE="$(get_iface_in_vip_subnet "$API_VIP")"
+export INTERFACE
 envsubst < /etc/keepalived/keepalived.conf.template | sudo tee /etc/keepalived/keepalived.conf
 
-podman run \
-        --rm \
+MATCHES="$(sudo podman ps -a --format "{{.Names}}" | awk '/keepalived$/ {print $0}')"
+if [[ -z "$MATCHES" ]]; then
+    podman create \
+        --name keepalived \
         --volume /etc/keepalived:/etc/keepalived:z \
         --network=host \
-        --cap-add=NET_ADMIN \
+        --privileged \
+        --cap-add=ALL \
         "${KEEPALIVED_IMAGE}" \
-        /usr/sbin/keepalived -f /etc/keepalived/keepalived.conf --dont-fork -D -l -P
-
-# Workaround for https://github.com/opencontainers/runc/pull/1807
-touch /etc/keepalived/.keepalived.done
+            /usr/sbin/keepalived -f /etc/keepalived/keepalived.conf \
+                --dont-fork -D -l -P
+fi

--- a/machineconfig/master/spec/config/systemd/units/keepalived.service.envsubst
+++ b/machineconfig/master/spec/config/systemd/units/keepalived.service.envsubst
@@ -2,12 +2,13 @@
 Description=Manage node VIPs with keepalived
 Wants=network-online.target
 After=network-online.target
-ConditionPathExists=!/etc/keepalived/.keepalived.done
 
 [Service]
 WorkingDirectory=/etc/keepalived
 Environment=API_VIP=${API_VIP}
-ExecStart=/usr/local/bin/keepalived.sh
+ExecStartPre=/usr/local/bin/keepalived.sh
+ExecStart=/usr/bin/podman start -a keepalived
+ExecStop=/usr/bin/podman stop -t 10 keepalived
 
 Restart=on-failure
 RestartSec=5


### PR DESCRIPTION
Some services do not yet handle well the VIPs being in the same
interface as the DHCP acquired address. While that happens, let hold the
VIPs in macvlan devices.

We should probably move back once the services deal with it better.