### PR TITLE
Makefile: Add all target.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
-.PHONY: default requirements configure repo_sync ironic build ocp_run clean ocp_cleanup host_cleanup
+.PHONY: default all requirements configure repo_sync ironic build ocp_run clean ocp_cleanup host_cleanup
 default: requirements configure repo_sync ironic build ocp_run
+
+all: default
 
 requirements:
 	./01_install_requirements.sh


### PR DESCRIPTION
"all" is a typical name for the default make target, so add it as an
alias for "default".  Then I can happily run "make clean all".