### PR TITLE
Patches for BM

### DIFF
--- a/06_deploy_bootstrap_vm.sh
+++ b/06_deploy_bootstrap_vm.sh
@@ -39,7 +39,9 @@ sudo systemctl reload NetworkManager
 $SSH -o ConnectionAttempts=500 core@$IP id
 
 # Create a master_nodes.json file
-jq '.nodes[0:3] | {nodes: .}' "${NODES_FILE}" | tee "${MASTER_NODES_FILE}"
+if [ "$NODES_PLATFORM" == "libvirt" ]; then
+  jq '.nodes[0:3] | {nodes: .}' "${NODES_FILE}" | tee "${MASTER_NODES_FILE}"
+fi
 
 # Generate "dynamic" ignition patches
 machineconfig_generate_patches "master"

--- a/07_deploy_masters.sh
+++ b/07_deploy_masters.sh
@@ -34,10 +34,9 @@ IMAGE_SOURCE="http://172.22.0.1/images/$RHCOS_IMAGE_FILENAME_LATEST"
 IMAGE_CHECKSUM=$(curl http://172.22.0.1/images/$RHCOS_IMAGE_FILENAME_LATEST.md5sum)
 
 ROOT_GB="25"
-ROOT_DEVICE="/dev/vda"
 
 for i in $(seq 0 2); do
-  master_node_to_tf $i $IMAGE_SOURCE $IMAGE_CHECKSUM $ROOT_GB $ROOT_DEVICE >> ocp/tf-master/main.tf
+  master_node_to_tf $i $IMAGE_SOURCE $IMAGE_CHECKSUM $ROOT_GB $ROOT_DISK >> ocp/tf-master/main.tf
 done
 
 echo "Deploying master nodes"

--- a/common.sh
+++ b/common.sh
@@ -13,8 +13,10 @@ PRO_IF=${PRO_IF:-}
 INT_IF=${INT_IF:-}
 #Root disk to deploy coreOS - use /dev/sda on BM
 ROOT_DISK=${ROOT_DISK:="/dev/vda"}
+# Default port of IPMI, will be used for BM
+DEFAULT_IPMI_PORT=${DEFAULT_IPMI_PORT:="623"}
 
-if [ -z "${CONFIG:-}" ]; then  
+if [ -z "${CONFIG:-}" ]; then
     # See if there's a config_$USER.sh in the SCRIPTDIR
     if [ -f ${SCRIPTDIR}/config_${USER}.sh ]; then
         echo "Using CONFIG ${SCRIPTDIR}/config_${USER}.sh"

--- a/utils.sh
+++ b/utils.sh
@@ -270,7 +270,11 @@ function master_node_to_tf() {
     local_gb=$(master_node_val ${master_idx} "properties.local_gb")
     cpu_arch=$(master_node_val ${master_idx} "properties.cpu_arch")
 
-    ipmi_port=$(master_node_val ${master_idx} "driver_info.ipmi_port")
+    if [ "$NODES_PLATFORM" == "libvirt" ]; then
+      ipmi_port=$(master_node_val ${master_idx} "driver_info.ipmi_port")
+    else
+      ipmi_port=$DEFAULT_IPMI_PORT
+    fi
     ipmi_username=$(master_node_val ${master_idx} "driver_info.ipmi_username")
     ipmi_password=$(master_node_val ${master_idx} "driver_info.ipmi_password")
     ipmi_address=$(master_node_val ${master_idx} "driver_info.ipmi_address")


### PR DESCRIPTION
Necessary patches for baremetal deployments
- ROOT_DISK was not being used in the TF
- Do not overwrite MASTER_NODES json if BM
- IPMI port with BM doesn't change