### PR TITLE
Use latest release image

### DIFF
--- a/ocp_install_env.sh
+++ b/ocp_install_env.sh
@@ -10,7 +10,7 @@ export SSH_PUB_KEY="`cat $HOME/.ssh/id_rsa.pub`"
 export SSH_PRIV_KEY="$HOME/.ssh/id_rsa"
 
 # Temporary workaround pending merge of https://github.com/openshift/machine-api-operator/pull/246
-export OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE="quay.io/vrutkovs/kni-release:mar14"
+export OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE="registry.svc.ci.openshift.org/openshift/origin-release:v4.0"
 
 function generate_ocp_install_config() {
     local outdir


### PR DESCRIPTION
machine-api now supports baremetal, use latest built release payload.

Depends on https://github.com/openshift-metalkube/kni-installer/pull/22