### PR TITLE
add a script to approve the certs after they expire

### DIFF
--- a/fix_certs.sh
+++ b/fix_certs.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+# https://github.com/openshift-metalkube/dev-scripts/issues/141#issuecomment-474331659
+
+oc get csr -o name | xargs -n 1 oc adm certificate approve


### PR DESCRIPTION
We shouldn't need this for very long, but to save everyone the effort
of keeping track of the command that needs to be run here's a script.