### PR TITLE
Removing leftover bootstrap VM as part of cleanup.

### DIFF
--- a/08_deploy_bmo.sh
+++ b/08_deploy_bmo.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/bash
 
+set -ex
+
 #source common.sh
 eval "$(go env)"
 

--- a/09_deploy_manifests.sh
+++ b/09_deploy_manifests.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/bash
 
+set -ex
+
 # FIXME - what are the prerequisites we need to wait for here, is waiting for 
 # bootstrap complete enough?
 


### PR DESCRIPTION
This patch aims to remove the leftover bootstrap
VM that remains on a hypervisor after clean.

Signed-off-by: Alexander Chuzhoy <achuzhoy@redhat.com>