### PR TITLE
Fix passwordHash syntax

### DIFF
--- a/assets/templates/99_master-core-password.yaml
+++ b/assets/templates/99_master-core-password.yaml
@@ -12,5 +12,4 @@ spec:
     passwd:
       users:
       - name: core
-        passwordHash:
-        - $6$2Cy8WeZ7uGbJ4qEv$vS8zP0HvbhtOTfu72JMoYIxm3Zb5T2880.vjwr9jug57uvwjuWmSJzjw9mUjgdTL4QSG2dvDpGaKJLHY741d./
+        passwordHash: '$6$2Cy8WeZ7uGbJ4qEv$vS8zP0HvbhtOTfu72JMoYIxm3Zb5T2880.vjwr9jug57uvwjuWmSJzjw9mUjgdTL4QSG2dvDpGaKJLHY741d./'


### PR DESCRIPTION
Fixes MCO complaining about wrong syntax in MachineConfiguration:
`
E0320 15:18:48.047943       1 reflector.go:134] github.com/openshift/machine-config-operator/pkg/generated/informers/externalversions/factory.go:101: Failed to list *v1.MachineConfig: v1.MachineConfigList.Items: []v1.MachineConfig: v1.MachineConfig.Spec: v1.MachineConfigSpec.Config: types.Config.Passwd: types.Passwd.Users: []types.PasswdUser: types.PasswdUser.PasswordHash: ReadString: expects " or n, but found [, error found in #10 byte of ...|ordHash":["$6$2Cy8We|..., bigger context ...|"passwd":{"users":[{"name":"core","passwordHash":["$6$2Cy8WeZ7uGbJ4qEv$vS8zP0HvbhtOTfu72JMoYIxm3Zb5T|...
`