### PR TITLE
Tolerate get events failure

### DIFF
--- a/utils.sh
+++ b/utils.sh
@@ -203,7 +203,7 @@ function wait_for_bootstrap_event() {
   max_attempts=60 # 60*10 = at least 10 mins of attempts
 
   for i in $(seq 0 "$max_attempts"); do
-    events=$(oc --request-timeout=5s --config ocp/auth/kubeconfig get events -n kube-system --no-headers -o wide)
+    events=$(oc --request-timeout=5s --config ocp/auth/kubeconfig get events -n kube-system --no-headers -o wide || echo 'Error retrieving events')
     echo "$events"
     if [[ ! $events =~ "bootstrap-complete" ]]; then 
       sleep "$pause";


### PR DESCRIPTION
This can fail due to timeout, e.g when the VIP fails over or of
the API is overloaded, in this case we should retry but we
won't if the parent script has set -e