### PR TITLE
Remove some remaining --config references

### DIFF
--- a/07_deploy_masters.sh
+++ b/07_deploy_masters.sh
@@ -60,11 +60,11 @@ echo "Master nodes up, you can ssh to the following IPs with core@<IP>"
 sudo virsh net-dhcp-leases baremetal
 
 # Wait for nodes to appear and become ready
-until oc --config ocp/auth/kubeconfig get nodes; do sleep 5; done
-NUM_NODES=$(oc --config ocp/auth/kubeconfig get nodes --no-headers | wc -l)
+until oc get nodes; do sleep 5; done
+NUM_NODES=$(oc get nodes --no-headers | wc -l)
 while [ "$NUM_NODES" -ne 3 ]; do
   sleep 10
-  NUM_NODES=$(oc --config ocp/auth/kubeconfig get nodes --no-headers | wc -l)
+  NUM_NODES=$(oc get nodes --no-headers | wc -l)
 done
 for i in $(seq 0 2); do
   oc wait nodes/master-$i --for condition=ready --timeout=600s

--- a/utils.sh
+++ b/utils.sh
@@ -191,9 +191,9 @@ EOF
 
 function collect_info_on_failure() {
     $SSH -o ConnectionAttempts=500 core@$IP sudo journalctl -b -u bootkube
-    oc --kubeconfig ocp/auth/kubeconfig get clusterversion/version
-    oc --kubeconfig ocp/auth/kubeconfig get clusteroperators
-    oc --kubeconfig ocp/auth/kubeconfig get pods --all-namespaces | grep -v Running | grep -v Completed
+    oc get clusterversion/version
+    oc get clusteroperators
+    oc get pods --all-namespaces | grep -v Running | grep -v Completed
 }
 
 function wait_for_bootstrap_event() {
@@ -203,7 +203,7 @@ function wait_for_bootstrap_event() {
   max_attempts=60 # 60*10 = at least 10 mins of attempts
 
   for i in $(seq 0 "$max_attempts"); do
-    events=$(oc --request-timeout=5s --config ocp/auth/kubeconfig get events -n kube-system --no-headers -o wide || echo 'Error retrieving events')
+    events=$(oc --request-timeout=5s get events -n kube-system --no-headers -o wide || echo 'Error retrieving events')
     echo "$events"
     if [[ ! $events =~ "bootstrap-complete" ]]; then 
       sleep "$pause";


### PR DESCRIPTION
I think some of these were missed in a rebase between #177 and #130

There are a few other places --config is used, but currently those
don't source common.sh, so I've left them alone for now.