### PR TITLE
Fix the boot device hacks to follow symlinks

### DIFF
--- a/04_setup_ironic.sh
+++ b/04_setup_ironic.sh
@@ -63,7 +63,7 @@ if [ ! -e "$RHCOS_IMAGE_FILENAME_DUALDHCP" ] ; then
     mkdir -p /tmp/mnt
     sudo kpartx -a /dev/$LOOPBACK
     sudo mount /dev/mapper/${LOOPBACK}p1 /tmp/mnt
-    sudo sed -i -e 's/ip=eth0:dhcp/ip=eth0:dhcp ip=eth1:dhcp/g' /tmp/mnt/grub2/grub.cfg 
+    sudo sed --follow-symlinks -i -e 's/ip=eth0:dhcp/ip=eth0:dhcp ip=eth1:dhcp/g' /tmp/mnt/grub2/grub.cfg
     sudo umount /tmp/mnt
     sudo kpartx -d /dev/${LOOPBACK}
     sudo losetup -d /dev/${LOOPBACK}

--- a/assets/files/usr/local/bin/rm-provision-nic.sh
+++ b/assets/files/usr/local/bin/rm-provision-nic.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
-PROVDEV=$(ip route get to 172.22.0.1 | awk '/dev/{print $3}')
-sudo sed -i.old -e "s/ ip=${PROVDEV}:dhcp//g" /boot/grub2/grub.cfg
+# Ensure we arn't mentioning the provisioning interface is the kernel
+# command line, doing so stalls dracut if dhcp isn't available on it
+sudo sed --follow-symlinks -i.old -e "s/ ip=eth0:dhcp//g" /boot/grub2/grub.cfg
+sudo sed --follow-symlinks -i.old -e 's/ip=eth0:dhcp/ip=eth1:dhcp/g' /etc/default/grub
 sync


### PR DESCRIPTION
sed needs to be told to follow a simlink to prevent it
from converting a softlink to a regular file. Converting
it to a regular file meant when pivot created a new grub.cfg
we were no longer pointing at it and as a result we attempting
to switch roots into the old ostree.

Also make sure the baremetal network is the one mentioned in
/etc/default/grub so its correct if grub.cfg is regenerated.