### PR TITLE
Add sudo for working_dir creation

### DIFF
--- a/common.sh
+++ b/common.sh
@@ -119,8 +119,8 @@ fi
 
 if [ ! -d "$WORKING_DIR" ]; then
   echo "Creating Working Dir"
-  mkdir "$WORKING_DIR"
-  chown "${USER}:${USER}" "$WORKING_DIR"
+  sudo mkdir "$WORKING_DIR"
+  sudo chown "${USER}:${USER}" "$WORKING_DIR"
   chmod 755 "$WORKING_DIR"
 fi
 


### PR DESCRIPTION
When running the scripts as a user, the creation of the WORKING_DIR fail as it try to create it under /opt as a simple user.

Simply added sudo to make the mkdir and chown commands work correctly.