### PR TITLE
set up the role binding before launching metalkube baremetal operator

### DIFF
--- a/08_deploy_bmo.sh
+++ b/08_deploy_bmo.sh
@@ -13,6 +13,6 @@ sed -i 's/bmo-project/openshift-machine-api/g' ocp/deploy/role_binding.yaml
 # Start deploying on the new cluster
 oc --config ocp/auth/kubeconfig apply -f ocp/deploy/service_account.yaml --namespace=openshift-machine-api
 oc --config ocp/auth/kubeconfig apply -f ocp/deploy/role.yaml --namespace=openshift-machine-api
-oc --config ocp/auth/kubeconfig apply -f ocp/deploy/operator.yaml --namespace=openshift-machine-api
 oc --config ocp/auth/kubeconfig apply -f ocp/deploy/role_binding.yaml
+oc --config ocp/auth/kubeconfig apply -f ocp/deploy/operator.yaml --namespace=openshift-machine-api
 oc --config ocp/auth/kubeconfig apply -f ocp/deploy/crds/metalkube_v1alpha1_baremetalhost_crd.yaml


### PR DESCRIPTION
The role binding is needed to give the operator permission, so we
should wait to launch the operator after the role binding is there.