### PR TITLE
be more resilient when changing the namespace for the bmo

### DIFF
--- a/08_deploy_bmo.sh
+++ b/08_deploy_bmo.sh
@@ -8,7 +8,7 @@ export BMOPATH="$GOPATH/src/github.com/metalkube/baremetal-operator"
 
 # Make a local copy of the baremetal-operator code to make changes
 cp -r $BMOPATH/deploy ocp/.
-sed -i 's/bmo-project/openshift-machine-api/g' ocp/deploy/role_binding.yaml
+sed -i 's/namespace: .*/namespace: openshift-machine-api/g' ocp/deploy/role_binding.yaml
 
 # Start deploying on the new cluster
 oc --config ocp/auth/kubeconfig apply -f ocp/deploy/service_account.yaml --namespace=openshift-machine-api


### PR DESCRIPTION
Change the sed pattern so we do not rely on what the current namespace
is, only on the fact that we are changing the namespace line. This
allows us to change the name we use when deploying on stock
kubernetes.