### PR TITLE
Configure etcd CNAME as a service

### DIFF
--- a/assets/files/etc/mdns/config.template
+++ b/assets/files/etc/mdns/config.template
@@ -3,7 +3,7 @@ collision_avoidance = "hostname"
 
 service {
     name = "Etcd"
-    host_name = "$MASTER_HOSTNAME"
+    host_name = "$ETCD_HOSTNAME"
     type = "_etcd-server-ssl._tcp"
     domain = "local."
     port = 2380
@@ -17,4 +17,13 @@ service {
     domain = "local."
     port = 42424
     ttl = 3200
+}
+
+service {
+    name = "EtcdWorkstation"
+    host_name = "$ETCD_HOSTNAME"
+    type = "_workstation._tcp"
+    domain = "local."
+    port = 42424
+    ttl = 300
 }


### PR DESCRIPTION
Instead of the semi-hard-coded CNAME generation in the coredns-mdns
plugin, use an mdns service record to create the etcd CNAMEs. This
is more flexible and will allow the plugin to be more generic since
it won't need to have OpenShift-specific logic in it.