### PR TITLE
Add support for Ingress VIP

### DIFF
--- a/06_deploy_bootstrap_vm.sh
+++ b/06_deploy_bootstrap_vm.sh
@@ -28,6 +28,8 @@ done
 IP=$(domain_net_ip ${INFRA_ID}-bootstrap baremetal)
 export API_VIP=$(dig +noall +answer "api.${CLUSTER_DOMAIN}" @$(network_ip baremetal) | awk '{print $NF}')
 echo "address=/api.${CLUSTER_DOMAIN}/${API_VIP}" | sudo tee /etc/NetworkManager/dnsmasq.d/openshift.conf
+export INGRESS_VIP=$(dig +noall +answer "ingress.${CLUSTER_DOMAIN}" @$(network_ip baremetal) | awk '{print $NF}')
+echo "address=/.apps.${CLUSTER_DOMAIN}/${INGRESS_VIP}" | sudo tee -a /etc/NetworkManager/dnsmasq.d/openshift.conf
 sudo systemctl reload NetworkManager
 
 # Wait for ssh to start

--- a/07_deploy_masters.sh
+++ b/07_deploy_masters.sh
@@ -77,4 +77,19 @@ for num in 0 1 2; do
   oc adm taint nodes master-${num} node-role.kubernetes.io/master:NoSchedule-
 done
 
+#Verify Ingress controller functionality
+echo "Verifying Ingress controller functionality, first we'll check that router pod responsive"
+until curl -o /dev/null -kLs --fail  tst.apps.${CLUSTER_DOMAIN}:1936/healthz; do sleep 20 && echo "Router pod not responding"; done
+
+echo "Create service named tst-svc"
+oc --config ocp/auth/kubeconfig  run --image=kuryr/demo  tst-svc
+oc --config ocp/auth/kubeconfig   scale dc/tst-svc  --replicas=2
+oc --config ocp/auth/kubeconfig    expose dc/tst-svc --port 1234 --target-port 8080
+echo "Create unsecured route pointing to tst-svc"
+oc --config ocp/auth/kubeconfig expose svc/tst-svc --hostname=www.example.com
+
+echo "Check connectivity via Ingress controller"
+until curl -o /dev/null -kLs --fail  --header 'Host: www.example.com'  tst.apps.${CLUSTER_DOMAIN}; do sleep 10 && echo "rechecking"; done
+echo "Ingress controller is working!"
+
 echo "Cluster up, you can interact with it via oc --config ocp/auth/kubeconfig <command>"

--- a/assets/files/etc/keepalived/keepalived.conf.template
+++ b/assets/files/etc/keepalived/keepalived.conf.template
@@ -10,6 +10,12 @@ vrrp_script chk_dns {
     weight 50
 }
 
+vrrp_script chk_ingress {
+    script "curl -o /dev/null -kLs https://0:1936/healthz"
+    interval 1
+    weight 50
+}
+
 vrrp_instance API {
     state BACKUP
     interface ${INTERFACE}
@@ -43,5 +49,23 @@ vrrp_instance DNS {
     }
     track_script {
         chk_dns
+    }
+}
+
+vrrp_instance INGRESS {
+    state BACKUP
+    interface ${INTERFACE}
+    virtual_router_id 53
+    priority 40
+    advert_int 1
+    authentication {
+        auth_type PASS
+        auth_pass cluster_uuid_ingress_vip
+    }
+    virtual_ipaddress {
+        192.168.111.4
+    }
+    track_script {
+        chk_ingress
     }
 }

--- a/assets/files/usr/local/bin/keepalived.sh
+++ b/assets/files/usr/local/bin/keepalived.sh
@@ -9,6 +9,7 @@ IFACE_CIDRS="$(ip addr show | grep -v "scope host" | grep -Po 'inet \K[\d.]+/[\d
 SUBNET_CIDR="$(/usr/local/bin/get_vip_subnet_cidr "$API_VIP" "$IFACE_CIDRS")"
 INTERFACE="$(ip -o addr show to "$SUBNET_CIDR" | awk '{print $2}')"
 DNS_VIP="$(/usr/local/bin/nthhost "$SUBNET_CIDR" 2)"
+INGRESS_VIP="$(dig +noall +answer "test.apps.${CLUSTER_DOMAIN}" | awk '{print $NF}')"
 
 KEEPALIVED_IMAGE="quay.io/celebdor/keepalived:latest"
 if ! podman inspect "$KEEPALIVED_IMAGE" &>/dev/null; then
@@ -19,6 +20,7 @@ fi
 export API_VIP
 export DNS_VIP
 export INTERFACE
+export INGRESS_VIP
 envsubst < /etc/keepalived/keepalived.conf.template | sudo tee /etc/keepalived/keepalived.conf
 
 MATCHES="$(sudo podman ps -a --format "{{.Names}}" | awk '/keepalived$/ {print $0}')"

--- a/tripleo-quickstart-config/roles/common/defaults/main.yml
+++ b/tripleo-quickstart-config/roles/common/defaults/main.yml
@@ -163,6 +163,12 @@ networks:
         - ip: "{{ baremetal_network_cidr | nthhost(5) }}"
           hostnames:
             - "api"
+        - ip: "{{ baremetal_network_cidr | nthhost(2) }}"
+          hostnames:
+            - "ns1"
+        - ip: "{{ baremetal_network_cidr | nthhost(4) }}"
+          hostnames:
+            - "ingress"
 
 network_isolation: true
 network_isolation_type: 'single-nic-vlans'


### PR DESCRIPTION
For the Openshift router support, the router pods will run on masters-nodes (host networking).
This patch adds support for the Ingress VIP(192.168.111.4), one of the master nodes will 'hold' this IP (VRRP), a wildcard external DNS entry should point to this VIP.