### PR TITLE
dns-vip-prepender: Prevent race with crio

### DIFF
--- a/assets/files/etc/NetworkManager/dispatcher.d/pre-up.d/dns-vip-prepender
+++ b/assets/files/etc/NetworkManager/dispatcher.d/pre-up.d/dns-vip-prepender
@@ -4,8 +4,8 @@ IFACE=$1
 STATUS=$2
 
 case "$STATUS" in
-    up)
-    logger -s "NM dns-vip-prepender triggered by upping ${1}."
+    pre-up)
+    logger -s "NM dns-vip-prepender triggered by pre-upping ${1}."
     set -e
     CLUSTER_DOMAIN="$(awk '/search/ {print $2}' /etc/resolv.conf)"
     API_VIP="$(dig +noall +answer "api.${CLUSTER_DOMAIN}" | awk '{print $NF}')"
@@ -32,8 +32,8 @@ case "$STATUS" in
     down)
     logger -s "NM dns-vip-prepender triggered by downing $IFACE"
     ;;
-    pre-up)
-    logger -s "NM dns-vip-prepender triggered by pre upping $IFACE"
+    up)
+    logger -s "NM dns-vip-prepender triggered by upping $IFACE"
     ;;
     post-down)
     logger -s "NM dns-vip-prepender triggered by post-downing $IFACE"

--- a/assets/templates/99_master-dhclient-dns.yaml
+++ b/assets/templates/99_master-dhclient-dns.yaml
@@ -20,4 +20,4 @@ spec:
           verification: {}
         filesystem: root
         mode: 0755
-        path: /etc/NetworkManager/dispatcher.d/dns-vip-prepender
+        path: /etc/NetworkManager/dispatcher.d/pre-up.d/dns-vip-prepender

--- a/assets/templates/99_worker-dhclient-dns.yaml
+++ b/assets/templates/99_worker-dhclient-dns.yaml
@@ -20,4 +20,4 @@ spec:
           verification: {}
         filesystem: root
         mode: 0755
-        path: /etc/NetworkManager/dispatcher.d/dns-vip-prepender
+        path: /etc/NetworkManager/dispatcher.d/pre-up.d/dns-vip-prepender


### PR DESCRIPTION
Cri-O and other service start after network-online.target.
dns-vip-prepender was being triggered by the NetworkManger dispatcher in
the "up" state, which happens right at network-online.target.
This means that if some service that ran after network-online target
needs CoreDNS mDNS resolution it may not get it depends on what happened
earlier. In order to address that, we move the dispatcher script to
"pre-up" which is strictly before NM desclares network-online.target as
achieved.