### PR TITLE
Bridges configuration adjustments for baremetal deployment

### DIFF
--- a/host_cleanup.sh
+++ b/host_cleanup.sh
@@ -24,6 +24,12 @@ ANSIBLE_FORCE_COLOR=true ansible-playbook \
     -b -vvv tripleo-quickstart-config/metalkube-teardown-playbook.yml
 
 sudo rm -rf /etc/NetworkManager/dnsmasq.d/openshift.conf /etc/NetworkManager/conf.d/dnsmasq.conf
+sudo rm -rf /etc/sysconfig/network-scripts/ifcfg-provisioning
+if [ "$INT_IF" ]; then
+  sudo rm -rf /etc/sysconfig/network-scripts/ifcfg-baremetal
+  sudo cp /etc/sysconfig/network-scripts/ifcfg-$INT_IF.orig /etc/sysconfig/network-scripts/ifcfg-$INT_IF
+  sudo systemctl restart network
+fi
 sudo virsh net-destroy baremetal
 sudo virsh net-undefine baremetal
 sudo virsh net-destroy provisioning

--- a/tripleo-quickstart-config/roles/common/tasks/main.yml
+++ b/tripleo-quickstart-config/roles/common/tasks/main.yml
@@ -1,0 +1,11 @@
+---
+- block:
+    - include_vars:
+        file: baremetal.yml
+    - name: register mac address of baremetal network interface
+      shell: |
+        /usr/sbin/ip l show dev {{ baremetal_interface }} | awk '/link/ {print $2}'
+      register: bm_mac
+    - set_fact:
+        baremetal_nic_mac: "{{ bm_mac.stdout }}"
+  when: platform == "baremetal"

--- a/tripleo-quickstart-config/roles/common/vars/baremetal.yml
+++ b/tripleo-quickstart-config/roles/common/vars/baremetal.yml
@@ -1,0 +1,217 @@
+# This directory is used to store a variety of files generated
+# during the deploy process (ansible inventory, ssh configuration, ssh
+# key files, etc)
+local_working_dir: "{{ lookup('env', 'HOME') }}/.quickstart"
+
+# this will define the user that ansible will connect with
+ssh_user: "{{ non_root_user }}"
+
+# This defines the users that deploys the overcloud from the undercloud
+# and accesses overcloud as the orchestration admin user
+undercloud_user: "{{ non_root_user }}"
+overcloud_user: heat-admin
+
+# This is where we store generated artifacts (like ssh config files,
+# keys, deployment scripts, etc) on the undercloud.
+#working_dir: "/opt/dev-scripts"
+
+# This is a directory no the virthost in which we store the downloaded
+# undercloud image.
+image_cache_dir: "/var/cache/tripleo-quickstart/images/{{ release }}"
+
+image_fetch_dir: "{{ working_dir }}"
+
+# This determines whether to download a pre-built undercloud.qcow2 or
+# whether to instead use an overcloud-full.qcow2 and convert it on
+# the fly. The default is to use a pre-built undercloud.qcow2.
+overcloud_as_undercloud: false
+
+# This determines whether or not to treat the undercloud.qcow2 as a
+# stock CentOS or RHEL image.  The default is a pre-built undercloud.qcow2
+baseos_as_undercloud: false
+
+# optionally setup the yum repos on the virthost
+virthost_repo_setup: false
+
+# When a base os image is used in lieu of a quickstart prepared image
+# additional setup steps are required for the undercloud install.
+undercloud_setup: false
+
+# Set selinux, by default RDO builds are always set to selinux permissive
+selinux_enforcing: false
+
+# These defaults are used if there are no flavor-specific
+# overrides configured.
+default_disk: 50
+default_memory: 8192
+
+# Setting controller and compute nodes to 2 vcpus, so we have more processing
+# power to run the tests
+default_vcpu: 2
+
+# The undercloud needs more than the default amount of memory
+# and disk.
+undercloud_memory: 12288
+undercloud_disk: 50
+# Setting undercloud to 6 cpus, so we continue to have around 10 vcpus
+# by default
+undercloud_vcpu: 6
+# base domain to use
+cluster_domain: "{{ lookup('env', 'CLUSTER_DOMAIN') | default('ostest.test.metalkube.org', true) }}"
+
+# The default deployment has flavors for compute, controllers, ceph
+# nodes, and undercloud nodes.  All flavors defined in the `flavors`
+# key will be created with an `oooq_` prefix to avoid conflicts with
+# the pre-defined flavors created by `openstack install undercloud`.
+flavors:
+  compute:
+    memory: '{{ compute_memory|default(default_memory) }}'
+    disk: '{{ compute_disk|default(default_disk) }}'
+    vcpu: '{{ compute_vcpu|default(default_vcpu) }}'
+
+  control:
+    memory: '{{ control_memory|default(default_memory) }}'
+    disk: '{{ control_disk|default(default_disk) }}'
+    vcpu: '{{ control_vcpu|default(default_vcpu) }}'
+
+  ceph:
+    memory: '{{ ceph_memory|default(default_memory) }}'
+    disk: '{{ ceph_disk|default(default_disk) }}'
+    vcpu: '{{ ceph_vcpu|default(default_vcpu) }}'
+    extradisks: true
+
+  blockstorage:
+    memory: '{{ block_memory|default(default_memory) }}'
+    disk: '{{ block_disk|default(default_disk) }}'
+    vcpu: '{{ block_vcpu|default(default_vcpu) }}'
+
+  objectstorage:
+    memory: '{{ objectstorage_memory|default(default_memory) }}'
+    disk: '{{ objectstorage_disk|default(default_disk) }}'
+    vcpu: '{{ objectstorage_vcpu|default(default_vcpu) }}'
+    extradisks: true
+
+  undercloud:
+    memory: '{{ undercloud_memory|default(undercloud_memory) }}'
+    disk: '{{ undercloud_disk|default(undercloud_disk) }}'
+    vcpu: '{{ undercloud_vcpu|default(undercloud_vcpu) }}'
+
+# We create a single undercloud node.
+undercloud_node:
+  name: undercloud
+  flavor: undercloud
+
+# Do not deploy supplemental nodes by default.
+deploy_supplemental_node: false
+
+# Do not deploy FreeIPA server by default.
+enable_tls_everywhere: false
+
+# allow the nic model to be overridden by environment variable
+overcloud_libvirt_nic_model: virtio
+
+# The overcloud will have three controllers, one compute node,
+# and a ceph storage node.
+overcloud_nodes:
+  - name: control_0
+    flavor: control
+  - name: control_1
+    flavor: control
+  - name: control_2
+    flavor: control
+
+  - name: compute_0
+    flavor: compute
+
+  - name: ceph_0
+    flavor: ceph
+
+# Describe our virtual networks.  These networks will be attached to
+# the undercloud node and to the overcloud nodes in the order in which
+# they are defined with the following caveats:
+#   *  If no networks are using forward_mode: 'nat', then the default libvirt
+#   network will be attached to the undercloud. This is required to ssh from the
+#   virt host to the undercloud
+#   *  The first bridge network defined will be used for pxe booting
+#
+baremetal_network_cidr: "{{ lookup('env', 'EXTERNAL_SUBNET') | default('192.168.111.0/24', true) }}"
+networks:
+  - name: provisioning
+    bridge: provisioning
+
+  - name: baremetal
+    bridge: baremetal
+
+network_isolation: true
+network_isolation_type: 'single-nic-vlans'
+enable_pacemaker: false
+ipv6: false
+
+# This enables the deployment of the overcloud with SSL.
+ssl_overcloud: false
+# If ssl_overcloud is True, then the overcloud public vip must be explicitly
+# specified as part of the deployment configuration. Note that the VIP used has
+# to be set accordingly with the `undercloud_external_network_cidr`.
+overcloud_public_vip: 10.0.0.5
+overcloud_public_vip6: 2001:db8:fd00:1000::14
+
+# Enable the virt_bmc ( virtual baremetal controllers )
+enable_vbmc: true
+
+# Set this to `false` if you don't want your undercloud and overcloud vms
+# to have a VNC console available.
+enable_vnc_console: true
+
+# We have some version specific behaviors, so we need a release variable
+#
+# TODO(trown): It would be better to write a release into the image itself
+# and set this variable from there.
+release: queens
+
+# This option controls whether or not to use the repo setup for TripleO
+# development. Since this requires some other options to be functional,
+# it is best to specify release master-tripleo-ci rather than
+# just flipping this to true.
+devmode: false
+
+# Tuned profile set while provisioning remote hosts to optimize for deployment
+tuned_profile: 'virtual-host'
+
+# This is the name of the user the `provision` role will create on the
+# remote host.
+non_root_group: "{{ non_root_user }}"
+
+# Path for volume storage
+libvirt_volume_path: "{{ working_dir }}/pool"
+
+libvirt_uri: qemu:///session
+
+# Whether to give permissive access to files owned by the non_root_user.
+# This is required if the non_root_user is not used to run libvirt tasks.
+# The most common case for this is when openvswitch is used for networks
+# on the virthost. This requires running libvirt tasks as the root user so
+# that they have sufficient privileges to connect to ovs bridges.
+non_root_chown: false
+
+# Enable port forwarding for tripleo-ui access
+# It is safe to mark this as default true as it only runs on a virthost
+# This variable is set to true in config/environments/default_libvirt.yml
+enable_port_forward_for_tripleo_ui: false
+
+# This enables the run of several tripleo-validations tests through Mistral
+run_tripleo_validations: false
+# This enables the run of tripleo-validations negative tests through shell
+# scripts
+run_tripleo_validations_negative_tests: false
+# Exit tripleo-quickstart on validations failures
+exit_on_validations_failure: false
+
+# Update undercloud and overcloud images with the repos provided via the
+# release config.
+update_images: false
+
+# If running in chroot-like environments (containers)
+chrooted: false
+
+# moved from tqe
+undercloud_generate_service_certificate: true

--- a/tripleo-quickstart-config/roles/environment/setup/templates/network.xml.j2
+++ b/tripleo-quickstart-config/roles/environment/setup/templates/network.xml.j2
@@ -12,6 +12,9 @@
   <bridge name='{{ item.bridge }}' stp='{{ stp }}' delay='{{ delay }}' />
 {% else %}
   <bridge name='{{ item.bridge }}'/>
+{% if item.name == 'baremetal' and platform == 'baremetal' %}
+  <mac address="{{ baremetal_nic_mac }}"/>
+{% endif %}
 {% endif %}
 {% if item.forward_mode is defined %}
   <forward mode='{{ item.forward_mode }}'>


### PR DESCRIPTION
**Bridges configuration adjustments for baremetal deployment**

This change implements the following changes to closer resemble
the documented networking requirements[1]:

 - when NODES_PLATFORM is set to baremetal tripleo-quickstart-config
   sets up the baremetal virsh network as a simple bridge. Currently
   the baremetal network is set up as a nat network providing dhcp
   and dns services which are not required as those are expected to be
   external to the provisioning host.
 - configure as mac address of the baremetal bridge the same mac address
   as $INT_IF. This is so we keep using the same DHCP IP address and not
   lose network connectivity when adding the interface to the bridge.
 - configure sysconfig networks scripts for the physical interfaces and
   bridges and then apply them via restarting the network service. This
   should prevent losing network connectivity and it's required for
   automation purposes.

[1] https://docs.google.com/document/d/1YGbpi1IoUHzRwHdXOF9La8AJsovM4WnixwGl_tch1Sc/edit
