### PR TITLE
Make the time to wait for bootstrap VM SSH configurable

### DIFF
--- a/06_deploy_bootstrap_vm.sh
+++ b/06_deploy_bootstrap_vm.sh
@@ -31,7 +31,7 @@ echo "address=/api.${CLUSTER_DOMAIN}/${API_VIP}" | sudo tee /etc/NetworkManager/
 sudo systemctl reload NetworkManager
 
 # Wait for ssh to start
-$SSH -o ConnectionAttempts=500 core@$IP id
+$SSH -o ConnectionAttempts=$BOOTSTRAP_SSH_READY core@$IP id
 
 # Create a master_nodes.json file
 jq '.nodes[0:3] | {nodes: .}' "${NODES_FILE}" | tee "${MASTER_NODES_FILE}"

--- a/common.sh
+++ b/common.sh
@@ -123,3 +123,6 @@ LOGFILE="$LOGDIR/$(basename $0 .sh)-$(date +%F-%H%M%S).log"
 echo "Logging to $LOGFILE"
 # Set fd 1 and 2 to write to the log file
 exec 1> >( tee "${LOGFILE}" ) 2>&1
+
+# Time to wait for SSH on bootstrap VM to become available
+BOOTSTRAP_SSH_READY=${BOOTSTRAP_SSH_READY:-500}


### PR DESCRIPTION
There may be situation where the SSH service on the bootstrap VM
takes longer to start. This change makes it configurable.