### PR TITLE
Increase timeout for services that download content

### DIFF
--- a/assets/templates/99_master-coredns.yaml
+++ b/assets/templates/99_master-coredns.yaml
@@ -25,6 +25,7 @@ spec:
 
             Restart=on-failure
             RestartSec=5
+            TimeoutStartSec=600
 
             [Install]
             WantedBy=multi-user.target

--- a/assets/templates/99_master-keepalived.yaml
+++ b/assets/templates/99_master-keepalived.yaml
@@ -25,6 +25,7 @@ spec:
 
             Restart=on-failure
             RestartSec=5
+            TimeoutStartSec=600
 
             [Install]
             WantedBy=multi-user.target

--- a/assets/templates/99_master-mdns-publisher.yaml
+++ b/assets/templates/99_master-mdns-publisher.yaml
@@ -25,6 +25,7 @@ spec:
 
             Restart=on-failure
             RestartSec=5
+            TimeoutStartSec=600
 
             [Install]
             WantedBy=multi-user.target

--- a/assets/templates/99_worker-coredns.yaml
+++ b/assets/templates/99_worker-coredns.yaml
@@ -22,6 +22,7 @@ spec:
             ExecStartPre=/usr/local/bin/coredns.sh
             ExecStart=/usr/bin/podman start -a coredns
             ExecStop=/usr/bin/podman stop -t 10 coredns
+            TimeoutStartSec=600
 
             Restart=on-failure
             RestartSec=5

--- a/assets/templates/99_worker-mdns-publisher.yaml
+++ b/assets/templates/99_worker-mdns-publisher.yaml
@@ -25,6 +25,7 @@ spec:
 
             Restart=on-failure
             RestartSec=5
+            TimeoutStartSec=600
 
             [Install]
             WantedBy=multi-user.target


### PR DESCRIPTION
When testing that with a slow connection, the services keep
restarting because they don't have enough time to download the
content. Increasing the timeout to, at least 10 minutes, ensures
that will work on more environments.