### PR TITLE
Enable extradisks and add root_device to ironic nodes

### DIFF
--- a/tripleo-quickstart-config/metalkube-nodes.yml
+++ b/tripleo-quickstart-config/metalkube-nodes.yml
@@ -32,10 +32,10 @@ flavors:
     memory: '{{openshift_memory|default(default_memory)}}'
     disk: '{{openshift_disk|default(default_disk)}}'
     vcpu: '{{openshift_vcpu|default(default_vcpu)}}'
-    extradisks: false
+    extradisks: true
 
   openshift_worker:
     memory: '{{openshift_memory|default(default_memory)}}'
     disk: '{{openshift_disk|default(default_disk)}}'
     vcpu: '{{openshift_vcpu|default(default_vcpu)}}'
-    extradisks: false
+    extradisks: true

--- a/tripleo-quickstart-config/roles/libvirt/defaults/main.yml
+++ b/tripleo-quickstart-config/roles/libvirt/defaults/main.yml
@@ -43,8 +43,6 @@ use_external_images: false
 # how many disks should be created when using extradisks
 extradisks_list:
   - vdb
-  - vdc
-  - vdd
 
 # size of the disks to create when using extradisks
 extradisks_size: 8G

--- a/utils.sh
+++ b/utils.sh
@@ -149,11 +149,14 @@ resource "ironic_node_v1" "openshift-master-${master_idx}" {
     "cpu_arch" =  "${cpu_arch}"
   }
 
+  root_device = {
+    "name" = "/dev/vda"
+  }
+
   instance_info = {
     "image_source" = "${image_source}"
     "image_checksum" = "${image_checksum}"
     "root_gb" = "${root_gb}"
-    "root_device" = "${root_device}"
   }
 
   driver = "${driver}"


### PR DESCRIPTION
This is required for enabling extra disks, e.g for rook/ceph

This also enables an extra disk so we can prove this works
and support testing with ceph/rook.

Note this requires https://github.com/openshift-metalkube/terraform-provider-ironic/pull/10