### PR TITLE
ocp_install_env: Refer to kni-installer

### DIFF
--- a/ocp_install_env.sh
+++ b/ocp_install_env.sh
@@ -1,6 +1,6 @@
 eval "$(go env)"
 
-export OPENSHIFT_INSTALL_DATA="$GOPATH/src/github.com/openshift/installer/data/data"
+export OPENSHIFT_INSTALL_DATA="$GOPATH/src/github.com/openshift-metalkube/kni-installer/data/data"
 export BASE_DOMAIN=test.metalkube.org
 export CLUSTER_NAME=ostest
 export CLUSTER_DOMAIN="${CLUSTER_NAME}.${BASE_DOMAIN}"


### PR DESCRIPTION
There was an old reference to openshift/installer that if not replaced
would make builds fail on environments in which openshift/installer was
not in GOPATH