### PR TITLE
baremetal: patch kube-system host-etcd real info

### DIFF
--- a/07_deploy_masters.sh
+++ b/07_deploy_masters.sh
@@ -65,6 +65,11 @@ while [ "$NUM_NODES" -ne 3 ]; do
   sleep 10
   NUM_NODES=$(oc --config ocp/auth/kubeconfig get nodes --no-headers | wc -l)
 done
+
+# Update kube-system ep/host-etcd used by cluster-kube-apiserver-operator to
+# generate storageConfig.urls
+patch_ep_host_etcd "$CLUSTER_DOMAIN"
+
 for i in $(seq 0 2); do
   oc wait nodes/master-$i --for condition=ready --timeout=600s
 done

--- a/utils.sh
+++ b/utils.sh
@@ -212,3 +212,49 @@ function wait_for_bootstrap_event() {
     fi
   done
 }
+
+function patch_ep_host_etcd() {
+    local host_etcd_ep
+    local hostnames
+    local address
+
+    declare -a etcd_hosts
+    declare -r domain="$1"
+    declare -r srv_record="_etcd-server-ssl._tcp.$domain"
+    declare -r api_domain="api.$domain"
+    host_etcd_ep=$(oc get ep -n kube-system host-etcd -o json | jq -r '{"subsets": .subsets}')
+    echo -n "Looking for etcd records"
+    while ! host -t SRV "$srv_record" "$api_domain" >/dev/null 2>&1; do
+        echo -n "."
+        sleep 1
+    done
+    echo " Found!"
+
+    mapfile -t hostnames < <(dig +noall +answer -t SRV "$srv_record" "@$api_domain" | awk '{print substr($NF, 1, length($NF)-1)}')
+
+    for hostname in "${hostnames[@]}"; do
+        address=$(dig +noall +answer "$hostname" "@$api_domain" | awk '$4 == "A" {print $NF}')
+        etcd_hosts+=($address\ $hostname)
+    done
+    patch=$(python -c "$(cat << 'EOF'
+import json
+import sys
+import yaml
+
+patch = json.loads(sys.argv[1])
+addresses = []
+for entry in sys.argv[2:]:
+    ip, hostname = entry.split()
+
+    if '.' in hostname:
+        hostname = hostname.split('.')[0]
+    addresses.append({'ip': ip, 'hostname': hostname})
+
+# remove old address entries
+del patch['subsets'][0]['addresses']
+patch['subsets'][0]['addresses'] = addresses
+print(yaml.safe_dump(patch))
+EOF
+    )" "$host_etcd_ep" "${etcd_hosts[@]}")
+    oc -n kube-system patch ep/host-etcd --patch "$patch"
+}


### PR DESCRIPTION
ep/host-etcd of the kube-system namespace is watched by the
cluster-kube-apiserver-operator to update storageConfig.urls.

Without this, errors such as the following are normal:

```W0328 12:54:56.070253       1 clientconn.go:944] grpc: addrConn.resetTransport failed to create client transport: connection error: desc = "transport: Error while dialing dial tcp: lookup etcd-0.dev1.kni.lab.eng.bos.redhat.com on 10.19.130.14:53: no such host"; Reconnecting to {etcd-0.dev1.kni.lab.eng.bos.redhat.com:2379 0  <nil>}```