### PR TITLE
Separating mariadb container

### DIFF
--- a/host_cleanup.sh
+++ b/host_cleanup.sh
@@ -4,7 +4,7 @@ set -x
 source common.sh
 
 # Kill and remove the running ironic containers
-for name in ironic ironic-inspector dnsmasq httpd; do
+for name in ironic ironic-inspector dnsmasq httpd mariadb; do
     sudo podman ps | grep -w "$name$" && sudo podman kill $name
     sudo podman ps --all | grep -w "$name$" && sudo podman rm $name -f
 done


### PR DESCRIPTION
This change also address the need to generate a random password
for the database user and pass it to both mariadb and
ironic container.
Relates to:
https://github.com/metalkube/metalkube-ironic/pull/23