### PR TITLE
Always source common.sh first

### DIFF
--- a/06_deploy_bootstrap_vm.sh
+++ b/06_deploy_bootstrap_vm.sh
@@ -2,8 +2,8 @@
 set -x
 set -e
 
-source ocp_install_env.sh
 source common.sh
+source ocp_install_env.sh
 source utils.sh
 
 if [ ! -d ocp ]; then

--- a/ocp_cleanup.sh
+++ b/ocp_cleanup.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 set -x
 
-source ocp_install_env.sh
 source common.sh
+source ocp_install_env.sh
 
 if [ -d ocp ]; then
     $GOPATH/src/github.com/openshift-metalkube/kni-installer/bin/kni-install --dir ocp --log-level=debug destroy bootstrap


### PR DESCRIPTION
Users may have custom variables set in config_<user>.sh
If they have a custom CLUSTER_NAME or BASE_DOMAIN, we need
to set these first, before the defaults are used to set
CLUSTER_DOMAIN in ocp_install_env.sh.