### PR TITLE
Remove ifcfg-provisioning during host_cleanup

### DIFF
--- a/host_cleanup.sh
+++ b/host_cleanup.sh
@@ -24,6 +24,8 @@ ANSIBLE_FORCE_COLOR=true ansible-playbook \
     -b -vvv tripleo-quickstart-config/metalkube-teardown-playbook.yml
 
 sudo rm -rf /etc/NetworkManager/dnsmasq.d/openshift.conf /etc/NetworkManager/conf.d/dnsmasq.conf
+# There was a bug in this file, it may need to be recreated.
+sudo rm -f /etc/sysconfig/network-scripts/ifcfg-provisioning
 sudo virsh net-destroy baremetal
 sudo virsh net-undefine baremetal
 sudo virsh net-destroy provisioning


### PR DESCRIPTION
There was a bug in this file previously, and it apparently doesn't
get updated properly. Remove the file during host cleanup so it will
be re-created correctly.