### PR TITLE
Add support for Ingress VIP

### DIFF
--- a/07_deploy_masters.sh
+++ b/07_deploy_masters.sh
@@ -73,4 +73,11 @@ for node in $(oc --config ocp/auth/kubeconfig get nodes --no-headers | sed -e 's
   oc label node $node node-role.kubernetes.io/worker=''
 done
 
+#Verify Ingress controller functionality
+echo "Verifying Ingress controller functionality, first we'll check that router pod responsive"
+until curl -o /dev/null -kLs --fail  tst.apps.${CLUSTER_DOMAIN}:1936/healthz; do sleep 20 && echo "Router pod not responding"; done
+echo "Router pod responding, checking connectivity to console via ingress controller"
+until wget --no-check-certificate https://console-openshift-console.apps.${CLUSTER_DOMAIN}; do sleep 10 && echo "rechecking"; done
+echo "Ingress controller is working!"
+
 echo "Cluster up, you can interact with it via oc --config ocp/auth/kubeconfig <command>"

--- a/assets/files/etc/keepalived/keepalived.conf.template
+++ b/assets/files/etc/keepalived/keepalived.conf.template
@@ -10,6 +10,12 @@ vrrp_script chk_dns {
     weight 50
 }
 
+vrrp_script chk_ingress {
+    script "curl -o /dev/null -kLs https://0:1936/healthz"
+    interval 1
+    weight 50
+}
+
 vrrp_instance API {
     state BACKUP
     interface ${INTERFACE}
@@ -43,5 +49,23 @@ vrrp_instance DNS {
     }
     track_script {
         chk_dns
+    }
+}
+
+vrrp_instance INGRESS {
+    state BACKUP
+    interface ${INTERFACE}
+    virtual_router_id 53
+    priority 40
+    advert_int 1
+    authentication {
+        auth_type PASS
+        auth_pass cluster_uuid_ingress_vip
+    }
+    virtual_ipaddress {
+        ${INGRESS_VIP}
+    }
+    track_script {
+        chk_ingress
     }
 }

--- a/assets/files/usr/local/bin/keepalived.sh
+++ b/assets/files/usr/local/bin/keepalived.sh
@@ -9,6 +9,7 @@ IFACE_CIDRS="$(ip addr show | grep -v "scope host" | grep -Po 'inet \K[\d.]+/[\d
 SUBNET_CIDR="$(/usr/local/bin/get_vip_subnet_cidr "$API_VIP" "$IFACE_CIDRS")"
 INTERFACE="$(ip -o addr show to "$SUBNET_CIDR" | awk '{print $2}')"
 DNS_VIP="$(dig +noall +answer "ns1.${CLUSTER_DOMAIN}" | awk '{print $NF}')"
+INGRESS_VIP="$(dig +noall +answer "test.apps.${CLUSTER_DOMAIN}" | awk '{print $NF}')"
 
 KEEPALIVED_IMAGE="quay.io/celebdor/keepalived:latest"
 if ! podman inspect "$KEEPALIVED_IMAGE" &>/dev/null; then
@@ -19,6 +20,7 @@ fi
 export API_VIP
 export DNS_VIP
 export INTERFACE
+export INGRESS_VIP
 envsubst < /etc/keepalived/keepalived.conf.template | sudo tee /etc/keepalived/keepalived.conf
 
 MATCHES="$(sudo podman ps -a --format "{{.Names}}" | awk '/keepalived$/ {print $0}')"

--- a/tripleo-quickstart-config/roles/common/defaults/main.yml
+++ b/tripleo-quickstart-config/roles/common/defaults/main.yml
@@ -166,6 +166,9 @@ networks:
         - ip: "{{ baremetal_network_cidr | nthhost(2) }}"
           hostnames:
             - "ns1"
+      forwarders:
+        - domain: "apps.{{ cluster_domain }}"
+          addr: "127.0.0.1"
 
 network_isolation: true
 network_isolation_type: 'single-nic-vlans'

--- a/tripleo-quickstart-config/roles/environment/setup/templates/network.xml.j2
+++ b/tripleo-quickstart-config/roles/environment/setup/templates/network.xml.j2
@@ -49,6 +49,11 @@
     <srv service='{{ srv.name }}' protocol='{{ srv.protocol }}' domain='{{ srv.domain }}' port='{{ srv.port }}' target='{{ srv.target }}' />
     {% endfor %}
   {% endif %}
+  {% if item.dns.forwarders is defined %}
+    {% for forwarder in item.dns.forwarders %}
+    <forwarder domain='{{ forwarder.domain }}' addr='{{ forwarder.addr }}' />
+    {% endfor %}
+  {% endif %}
   </dns>
 {% endif %}
 {% endif %}


### PR DESCRIPTION
For the Openshift router support, the router pods will run on
masters-nodes (host networking).
This patch adds support for the Ingress VIP(192.168.111.4), one
of the master nodes will hold this IP (VRRP), creates wildcard
external DNS entry pointing to Ingress VIP and adds e2e verifictation test.

Co-authored-by: Antoni Segura Puimedon <antoni@redhat.com>