### PR TITLE
Restart network service instead of ifdown to avoid losing connectivity

### DIFF
--- a/02_configure_host.sh
+++ b/02_configure_host.sh
@@ -123,13 +123,15 @@ if ! sudo iptables -C INPUT -p tcp --dport 3000 -j ACCEPT 2>/dev/null ; then
 fi
 
 # Switch NetworkManager to internal DNS
-sudo mkdir -p /etc/NetworkManager/conf.d/
-sudo crudini --set /etc/NetworkManager/conf.d/dnsmasq.conf main dns dnsmasq
-if [ "$ADDN_DNS" ] ; then
-  echo "server=$ADDN_DNS" | sudo tee /etc/NetworkManager/dnsmasq.d/upstream.conf
-fi
-if systemctl is-active --quiet NetworkManager; then
-  sudo systemctl reload NetworkManager
-else
-  sudo systemctl restart NetworkManager
+if [ "$MANAGE_BR_BRIDGE" == "y" ] ; then
+  sudo mkdir -p /etc/NetworkManager/conf.d/
+  sudo crudini --set /etc/NetworkManager/conf.d/dnsmasq.conf main dns dnsmasq
+  if [ "$ADDN_DNS" ] ; then
+    echo "server=$ADDN_DNS" | sudo tee /etc/NetworkManager/dnsmasq.d/upstream.conf
+  fi
+  if systemctl is-active --quiet NetworkManager; then
+    sudo systemctl reload NetworkManager
+  else
+    sudo systemctl restart NetworkManager
+  fi
 fi

--- a/02_configure_host.sh
+++ b/02_configure_host.sh
@@ -73,14 +73,14 @@ sudo ifup baremetal
 # external access so we need to make sure we maintain dhcp config if its available
 if [ "$INT_IF" ]; then
     echo -e "DEVICE=$INT_IF\nTYPE=Ethernet\nONBOOT=yes\nNM_CONTROLLED=no\nBRIDGE=baremetal" | sudo dd of=/etc/sysconfig/network-scripts/ifcfg-$INT_IF
-    sudo ifdown $INT_IF || true
-    sudo ifup $INT_IF
     if sudo nmap --script broadcast-dhcp-discover -e $INT_IF | grep "IP Offered" ; then
         echo -e "\nBOOTPROTO=dhcp\n" | sudo tee -a /etc/sysconfig/network-scripts/ifcfg-baremetal
-        sudo ifdown baremetal || true
-        sudo ifup baremetal
+        sudo systemctl restart network
+    else
+        sudo systemctl restart network
     fi
 fi
+
 # restart the libvirt network so it applies an ip to the bridge
 if [ "$MANAGE_BR_BRIDGE" == "y" ] ; then
     sudo virsh net-destroy baremetal                                                                                                                                                                  

--- a/06_deploy_bootstrap_vm.sh
+++ b/06_deploy_bootstrap_vm.sh
@@ -22,11 +22,11 @@ INFRA_ID=$(jq -r .infraID ocp/metadata.json)
 # NOTE: This is equivalent to the external API DNS record pointing the API to the API VIP
 if [ "$MANAGE_BR_BRIDGE" == "y" ] ; then
     export API_VIP=$(dig +noall +answer "api.${CLUSTER_DOMAIN}" @$(network_ip baremetal) | awk '{print $NF}')
+    echo "address=/api.${CLUSTER_DOMAIN}/${API_VIP}" | sudo tee /etc/NetworkManager/dnsmasq.d/openshift.conf
+    sudo systemctl reload NetworkManager
 else
     export API_VIP=$(dig +noall +answer "api.${CLUSTER_DOMAIN}"  | awk '{print $NF}')
 fi
-echo "address=/api.${CLUSTER_DOMAIN}/${API_VIP}" | sudo tee /etc/NetworkManager/dnsmasq.d/openshift.conf
-sudo systemctl reload NetworkManager
 
 # Wait for ssh to start
 $SSH -o ConnectionAttempts=$BOOTSTRAP_SSH_READY core@$API_VIP id


### PR DESCRIPTION
To avoid losing network connectivity when bridging the physical interface
to the baremetal bridge we can use systemctl restart network. This is
useful for persisting the SSH connection when automating the deployment.

Also when the baremetal bridge is not managed by libvirt the provsioning host
uses the external DNS server for name resolution. This change sets the
condition so NetworkManager dnsmasq gets used only when the baremetal bridge
is managed by libvirt.