### PR TITLE
root_disk shouldn't be hardcoded

### DIFF
--- a/utils.sh
+++ b/utils.sh
@@ -150,7 +150,7 @@ resource "ironic_node_v1" "openshift-master-${master_idx}" {
   }
 
   root_device = {
-    "name" = "/dev/vda"
+    "name" = "${ROOT_DISK}"
   }
 
   instance_info = {


### PR DESCRIPTION
Using the variable for root_disk that was
set by the user in config_${USER}.sh file.

Signed-off-by: Alexander Chuzhoy <achuzhoy@redhat.com>