### PR TITLE
keepalived: include cluster name in instance, pass

### DIFF
--- a/assets/files/etc/kubernetes/manifests/keepalived.yaml
+++ b/assets/files/etc/kubernetes/manifests/keepalived.yaml
@@ -19,6 +19,9 @@ spec:
   - name: get-vip-subnet-cidr
     hostPath:
       path: "/usr/local/bin/get_vip_subnet_cidr"
+  - name: fletcher8
+    hostPath:
+      path: "/usr/local/bin/fletcher8"
   - name: conf-dir
     empty-dir: {}
   initContainers:
@@ -45,6 +48,7 @@ spec:
       set -ex
 
       source /etc/kubernetes/static-pod-resources/clusterrc
+      CLUSTER_NAME="$NAME"
       API_VIP="$(dig +noall +answer "api.${DOMAIN}" | awk '{print $NF}')"
       IFACE_CIDRS="$(ip addr show | grep -v "scope host" | grep -Po 'inet \K[\d.]+/[\d.]+' | xargs)"
       SUBNET_CIDR="$(/usr/local/bin/get_vip_subnet_cidr "$API_VIP" "$IFACE_CIDRS")"
@@ -52,11 +56,20 @@ spec:
       DNS_VIP="$(dig +noall +answer "ns1.${DOMAIN}" | awk '{print $NF}')"
       INGRESS_VIP="$(dig +noall +answer "test.apps.${DOMAIN}" | awk '{print $NF}')"
 
+      # Virtual Router IDs. They must be different and 8 bit in length
+      API_VRID=$(/usr/local/bin/fletcher8 "${CLUSTER_NAME}-api")
+      DNS_VRID=$(/usr/local/bin/fletcher8 "${CLUSTER_NAME}-dns")
+      INGRESS_VRID=$(/usr/local/bin/fletcher8 "${CLUSTER_NAME}-ingress")
+
       export DOMAIN
+      export CLUSTER_NAME
       export INTERFACE
       export API_VIP
       export DNS_VIP
       export INGRESS_VIP
+      export API_VRID
+      export DNS_VRID
+      export INGRESS_VRID
       /usr/libexec/platform-python -c "from __future__ import print_function
       import os
       with open('/etc/kubernetes/static-pod-resources/keepalived.conf.template', 'r') as f:
@@ -72,6 +85,8 @@ spec:
       mountPath: "/etc/keepalived"
     - name: get-vip-subnet-cidr
       mountPath: "/usr/local/bin/get_vip_subnet_cidr"
+    - name: fletcher8
+      mountPath: "/usr/local/bin/fletcher8"
     imagePullPolicy: IfNotPresent
   containers:
   - name: keepalived

--- a/assets/files/etc/kubernetes/static-pod-resources/keepalived/keepalived.conf.template
+++ b/assets/files/etc/kubernetes/static-pod-resources/keepalived/keepalived.conf.template
@@ -16,15 +16,15 @@ vrrp_script chk_ingress {
     weight 50
 }
 
-vrrp_instance API {
+vrrp_instance ${CLUSTER_NAME}_API {
     state BACKUP
     interface ${INTERFACE}
-    virtual_router_id 51
+    virtual_router_id ${API_VRID}
     priority 40
     advert_int 1
     authentication {
         auth_type PASS
-        auth_pass cluster_uuid_api_vip
+        auth_pass ${CLUSTER_NAME}_api_vip
     }
     virtual_ipaddress {
         ${API_VIP}
@@ -34,15 +34,15 @@ vrrp_instance API {
     }
 }
 
-vrrp_instance DNS {
+vrrp_instance ${CLUSTER_NAME}_DNS {
     state BACKUP
     interface ${INTERFACE}
-    virtual_router_id 52
+    virtual_router_id ${DNS_VRID}
     priority 40
     advert_int 1
     authentication {
         auth_type PASS
-        auth_pass cluster_uuid_dns_vip
+        auth_pass ${CLUSTER_NAME}_dns_vip
     }
     virtual_ipaddress {
         ${DNS_VIP}
@@ -52,10 +52,10 @@ vrrp_instance DNS {
     }
 }
 
-vrrp_instance INGRESS {
+vrrp_instance ${CLUSTER_NAME}_INGRESS {
     state BACKUP
     interface ${INTERFACE}
-    virtual_router_id 53
+    virtual_router_id ${INGRESS_VRID}
     priority 40
     advert_int 1
     authentication {

--- a/assets/files/usr/local/bin/fletcher8
+++ b/assets/files/usr/local/bin/fletcher8
@@ -1,0 +1,10 @@
+#!/usr/libexec/platform-python
+import sys
+
+data = map(ord, sys.argv[1])
+ckA = ckB = 0
+
+for b in data:
+    ckA = (ckA + b) & 0xf
+    ckB = (ckB + ckA) & 0xf
+print((ckB << 4) | ckA )

--- a/assets/templates/99_master-utils.yaml
+++ b/assets/templates/99_master-utils.yaml
@@ -21,3 +21,8 @@ spec:
         filesystem: root
         mode: 0775
         path: /usr/local/bin/get_vip_subnet_cidr
+      - contents:
+          verification: {}
+        filesystem: root
+        mode: 0775
+        path: /usr/local/bin/fletcher8


### PR DESCRIPTION
In order to enable multiple clusters in the same broadcast domain we
must make sure that the VRRP IP management of the different clusters
don't end up mixing up.