### PR TITLE
Set volumeSource to emptyDir in image-registry operator

### DIFF
--- a/assets/templates/99_registry.yaml
+++ b/assets/templates/99_registry.yaml
@@ -1,0 +1,20 @@
+# FIXME: Reconfigure this once Rook is deployed
+apiVersion: imageregistry.operator.openshift.io/v1
+kind: Config
+metadata:
+  generation: 1
+  name: cluster
+spec:
+  logging: 2
+  managementState: Managed
+  proxy: {}
+  replicas: 1
+  requests:
+    read:
+      maxWaitInQueue: 0s
+    write:
+      maxWaitInQueue: 0s
+  storage:
+    filesystem:
+      volumeSource:
+        emptyDir: {}


### PR DESCRIPTION
This makes image-registry operator pass. In the prod version Rook should be deployed first to avoid using emptyDir for registry.

Once Rook code is finalized this config should be updated