### PR TITLE
Add the possibility of not managing bridges

### DIFF
--- a/02_configure_host.sh
+++ b/02_configure_host.sh
@@ -46,45 +46,49 @@ EOF
     virsh pool-autostart default
 fi
 
-# Adding an IP address in the libvirt definition for this network results in
-# dnsmasq being run, we don't want that as we have our own dnsmasq, so set
-# the IP address here
-if [ ! -e /etc/sysconfig/network-scripts/ifcfg-provisioning ] ; then
-    echo -e "DEVICE=provisioning\nTYPE=Bridge\nONBOOT=yes\nNM_CONTROLLED=no\nBOOTPROTO=static\nIPADDR=172.22.0.1\nNETMASK=255.255.255.0" | sudo dd of=/etc/sysconfig/network-scripts/ifcfg-provisioning
-fi
-sudo ifdown provisioning || true
-sudo ifup provisioning
+if [ "$MANAGE_PRO_BRIDGE" == "y" ]; then
+    # Adding an IP address in the libvirt definition for this network results in
+    # dnsmasq being run, we don't want that as we have our own dnsmasq, so set
+    # the IP address here
+    if [ ! -e /etc/sysconfig/network-scripts/ifcfg-provisioning ] ; then
+        echo -e "DEVICE=provisioning\nTYPE=Bridge\nONBOOT=yes\nNM_CONTROLLED=no\nBOOTPROTO=static\nIPADDR=172.22.0.1\nNETMASK=255.255.255.0" | sudo dd of=/etc/sysconfig/network-scripts/ifcfg-provisioning
+    fi
+    sudo ifdown provisioning || true
+    sudo ifup provisioning
 
-# Need to pass the provision interface for bare metal
-if [ "$PRO_IF" ]; then
-    echo -e "DEVICE=$PRO_IF\nTYPE=Ethernet\nONBOOT=yes\nNM_CONTROLLED=no\nBRIDGE=provisioning" | sudo dd of=/etc/sysconfig/network-scripts/ifcfg-$PRO_IF
-    sudo ifdown $PRO_IF || true
-    sudo ifup $PRO_IF
+    # Need to pass the provision interface for bare metal
+    if [ "$PRO_IF" ]; then
+        echo -e "DEVICE=$PRO_IF\nTYPE=Ethernet\nONBOOT=yes\nNM_CONTROLLED=no\nBRIDGE=provisioning" | sudo dd of=/etc/sysconfig/network-scripts/ifcfg-$PRO_IF
+        sudo ifdown $PRO_IF || true
+        sudo ifup $PRO_IF
+    fi
 fi
 
-# Create the baremetal bridge
-if [ ! -e /etc/sysconfig/network-scripts/ifcfg-baremetal ] ; then
-    echo -e "DEVICE=baremetal\nTYPE=Bridge\nONBOOT=yes\nNM_CONTROLLED=no" | sudo dd of=/etc/sysconfig/network-scripts/ifcfg-baremetal
-fi
-sudo ifdown baremetal || true
-sudo ifup baremetal
+if [ "$MANAGE_PRO_BRIDGE" == "y" ]; then
+    # Create the baremetal bridge
+    if [ ! -e /etc/sysconfig/network-scripts/ifcfg-baremetal ] ; then
+        echo -e "DEVICE=baremetal\nTYPE=Bridge\nONBOOT=yes\nNM_CONTROLLED=no" | sudo dd of=/etc/sysconfig/network-scripts/ifcfg-baremetal
+    fi
+    sudo ifdown baremetal || true
+    sudo ifup baremetal
 
-# Add the internal interface to it if requests, this may also be the interface providing
-# external access so we need to make sure we maintain dhcp config if its available
-if [ "$INT_IF" ]; then
-    echo -e "DEVICE=$INT_IF\nTYPE=Ethernet\nONBOOT=yes\nNM_CONTROLLED=no\nBRIDGE=baremetal" | sudo dd of=/etc/sysconfig/network-scripts/ifcfg-$INT_IF
-    if sudo nmap --script broadcast-dhcp-discover -e $INT_IF | grep "IP Offered" ; then
-        echo -e "\nBOOTPROTO=dhcp\n" | sudo tee -a /etc/sysconfig/network-scripts/ifcfg-baremetal
-        sudo systemctl restart network
-    else
-        sudo systemctl restart network
+    # Add the internal interface to it if requests, this may also be the interface providing
+    # external access so we need to make sure we maintain dhcp config if its available
+    if [ "$INT_IF" ]; then
+        echo -e "DEVICE=$INT_IF\nTYPE=Ethernet\nONBOOT=yes\nNM_CONTROLLED=no\nBRIDGE=baremetal" | sudo dd of=/etc/sysconfig/network-scripts/ifcfg-$INT_IF
+        if sudo nmap --script broadcast-dhcp-discover -e $INT_IF | grep "IP Offered" ; then
+            echo -e "\nBOOTPROTO=dhcp\n" | sudo tee -a /etc/sysconfig/network-scripts/ifcfg-baremetal
+            sudo systemctl restart network
+        else
+           sudo systemctl restart network
+        fi
     fi
 fi
 
 # restart the libvirt network so it applies an ip to the bridge
 if [ "$MANAGE_BR_BRIDGE" == "y" ] ; then
-    sudo virsh net-destroy baremetal                                                                                                                                                                  
-    sudo virsh net-start baremetal   
+    sudo virsh net-destroy baremetal
+    sudo virsh net-start baremetal
 fi
 
 # Add firewall rules to ensure the IPA ramdisk can reach httpd, Ironic and the Inspector API on the host

--- a/common.sh
+++ b/common.sh
@@ -26,6 +26,9 @@ EXT_IF=${EXT_IF:-}
 PRO_IF=${PRO_IF:-}
 # Does libvirt manage the baremetal bridge (including DNS and DHCP)
 MANAGE_BR_BRIDGE=${MANAGE_BR_BRIDGE:-y}
+# Only manage bridges if is set
+MANAGE_PRO_BRIDGE=${MANAGE_PRO_BRIDGE:-y}
+MANAGE_INT_BRIDGE=${MANAGE_INT_BRIDGE:-y}
 # Internal interface, to bridge virbr0
 INT_IF=${INT_IF:-}
 #Root disk to deploy coreOS - use /dev/sda on BM

--- a/host_cleanup.sh
+++ b/host_cleanup.sh
@@ -4,7 +4,7 @@ set -x
 source common.sh
 
 # Kill and remove the running ironic containers
-for name in ironic ironic-inspector dnsmasq httpd; do 
+for name in ironic ironic-inspector dnsmasq httpd; do
     sudo podman ps | grep -w "$name$" && sudo podman kill $name
     sudo podman ps --all | grep -w "$name$" && sudo podman rm $name -f
 done
@@ -25,7 +25,9 @@ ANSIBLE_FORCE_COLOR=true ansible-playbook \
 
 sudo rm -rf /etc/NetworkManager/dnsmasq.d/openshift.conf /etc/NetworkManager/conf.d/dnsmasq.conf
 # There was a bug in this file, it may need to be recreated.
-sudo rm -f /etc/sysconfig/network-scripts/ifcfg-provisioning
+if [ "$MANAGE_PRO_BRIDGE" == "y" ]; then
+    sudo rm -f /etc/sysconfig/network-scripts/ifcfg-provisioning
+fi
 sudo virsh net-destroy baremetal
 sudo virsh net-undefine baremetal
 sudo virsh net-destroy provisioning


### PR DESCRIPTION
Create 2 new vars MANAGE_PRO_BRIDGE and MANAGE_INT_BRIDGE. If those
are set to n, the scripts won't try to recreate the bridges, but
leave the ones that are already created on the host.
This is useful for specific configurations where settings
cannot be overwritten.