### PR TITLE
add custom version of make-bm-worker

### DIFF
--- a/make-bm-worker/README.md
+++ b/make-bm-worker/README.md
@@ -1,0 +1,69 @@
+Registering Bare Metal Hosts
+============================
+
+The `make-bm-worker` tool may be a more convenient way of creating
+YAML definitions for workers than editing the files directly.
+
+```
+$ go run make-bm-worker/main.go -address ipmi://192.168.111.1:6233 -password password -user admin worker-99
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: worker-99-bmc-secret
+type: Opaque
+data:
+  username: YWRtaW4=
+  password: cGFzc3dvcmQ=
+
+---
+apiVersion: metalkube.org/v1alpha1
+kind: BareMetalHost
+metadata:
+  name: worker-99
+spec:
+  online: true
+  bmc:
+    address: ipmi://192.168.111.1:6233
+    credentialsName: worker-99-bmc-secret
+```
+
+The output can be passed directly to `oc apply` like this:
+
+```
+$ go run make-bm-worker/main.go -address ipmi://192.168.111.1:6233 -password password -user admin worker-99 | oc apply -f -
+```
+
+Include the `-image` option to include the image settings needed to
+trigger immediate provisioning:
+
+```
+$ go run make-bm-worker/main.go -address ipmi://192.168.111.1:6233 -password password -user admin -image worker-99
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: worker-99-bmc-secret
+type: Opaque
+data:
+  username: YWRtaW4=
+  password: cGFzc3dvcmQ=
+
+---
+apiVersion: metalkube.org/v1alpha1
+kind: BareMetalHost
+metadata:
+  name: worker-99
+spec:
+  online: true
+  bmc:
+    address: ipmi://192.168.111.1:6233
+    credentialsName: worker-99-bmc-secret
+
+  userData:
+    namespace: openshift-machine-api
+    name: worker-user-data
+  image:
+    url: "http://172.22.0.1/images/redhat-coreos-maipo-latest.qcow2"
+    checksum: "http://172.22.0.1/images/redhat-coreos-maipo-latest.qcow2.md5sum"
+```

--- a/make-bm-worker/main.go
+++ b/make-bm-worker/main.go
@@ -1,0 +1,107 @@
+package main
+
+import (
+	"encoding/base64"
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+	"text/template"
+)
+
+const (
+	instanceImageSource      = "http://172.22.0.1/images/redhat-coreos-maipo-latest.qcow2"
+	instanceImageChecksumURL = instanceImageSource + ".md5sum"
+)
+
+var templateBody = `---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Name }}-bmc-secret
+type: Opaque
+data:
+  username: {{ .EncodedUsername }}
+  password: {{ .EncodedPassword }}
+
+---
+apiVersion: metalkube.org/v1alpha1
+kind: BareMetalHost
+metadata:
+  name: {{ .Name }}
+spec:
+  online: true
+  bmc:
+    address: {{ .BMCAddress }}
+    credentialsName: {{ .Name }}-bmc-secret
+{{- if .WithImage }}
+  userData:
+    namespace: openshift-machine-api
+    name: worker-user-data
+  image:
+    url: "{{ .ImageSourceURL }}"
+    checksum: "{{ .Checksum }}"
+{{ end -}}
+`
+
+// TemplateArgs holds the arguments to pass to the template.
+type TemplateArgs struct {
+	Name            string
+	BMCAddress      string
+	EncodedUsername string
+	EncodedPassword string
+	WithImage       bool
+	Checksum        string
+	ImageSourceURL  string
+}
+
+func encodeToSecret(input string) string {
+	return base64.StdEncoding.EncodeToString([]byte(input))
+}
+
+func main() {
+	var username = flag.String("user", "", "username for BMC")
+	var password = flag.String("password", "", "password for BMC")
+	var bmcAddress = flag.String("address", "", "address URL for BMC")
+	var verbose = flag.Bool("v", false, "turn on verbose output")
+	var withImage = flag.Bool("image", false, "include the image settings to trigger deployment")
+
+	flag.Parse()
+
+	hostName := flag.Arg(0)
+	if hostName == "" {
+		fmt.Fprintf(os.Stderr, "Missing name argument\n")
+		os.Exit(1)
+	}
+	if *username == "" {
+		fmt.Fprintf(os.Stderr, "Missing -user argument\n")
+		os.Exit(1)
+	}
+	if *password == "" {
+		fmt.Fprintf(os.Stderr, "Missing -password argument\n")
+		os.Exit(1)
+	}
+	if *bmcAddress == "" {
+		fmt.Fprintf(os.Stderr, "Missing -address argument\n")
+		os.Exit(1)
+	}
+
+	args := TemplateArgs{
+		Name:            strings.Replace(hostName, "_", "-", -1),
+		BMCAddress:      *bmcAddress,
+		EncodedUsername: encodeToSecret(*username),
+		EncodedPassword: encodeToSecret(*password),
+		WithImage:       *withImage,
+		Checksum:        instanceImageChecksumURL,
+		ImageSourceURL:  instanceImageSource,
+	}
+	if *verbose {
+		fmt.Fprintf(os.Stderr, "%v", args)
+	}
+
+	t := template.Must(template.New("yaml_out").Parse(templateBody))
+	err := t.Execute(os.Stdout, args)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "ERROR: %s\n", err)
+	}
+}


### PR DESCRIPTION
Add a version of the tool for making a baremetal worker that knows
how to set the image properties to trigger provisioning immediately.