### PR TITLE
Set timeout on CI run

### DIFF
--- a/run_ci.sh
+++ b/run_ci.sh
@@ -84,7 +84,7 @@ done
 
 # Run dev-scripts
 set -o pipefail
-make |& ts "%b %d %H:%M:%S | " |& sed -e 's/.*auths.*/*** PULL_SECRET ***/g'
+timeout -s 9 85m make |& ts "%b %d %H:%M:%S | " |& sed -e 's/.*auths.*/*** PULL_SECRET ***/g'
 
 # Populate cache for files it doesn't have
 for FILE in $FILESTOCACHE ; do


### PR DESCRIPTION
The jenkins job times out after 90 minutes, we need to
also timeout the "make" command so it times out before
jenkins and there is time to grab the logs.