### PR TITLE
Fix systemd podman services for rhel8 image

### DIFF
--- a/assets/files/usr/local/bin/coredns.sh
+++ b/assets/files/usr/local/bin/coredns.sh
@@ -3,7 +3,7 @@ set -e
 
 mkdir --parents /etc/coredns
 
-CLUSTER_DOMAIN="$(clusterinfo CLUSTER_DOMAIN)"
+CLUSTER_DOMAIN="$(/usr/local/bin/clusterinfo CLUSTER_DOMAIN)"
 read -d '.' -a CLUSTER_ARR <<< $CLUSTER_DOMAIN
 CLUSTER_NAME=${CLUSTER_ARR[0]}
 DNS_VIP="$(dig +noall +answer "ns1.${CLUSTER_DOMAIN}" | awk '{print $NF}')"

--- a/assets/files/usr/local/bin/haproxy.sh
+++ b/assets/files/usr/local/bin/haproxy.sh
@@ -145,7 +145,7 @@ function sighandler {
     trap - SIGINT SIGTERM
 }
 
-CLUSTER_DOMAIN="$(clusterinfo CLUSTER_DOMAIN)"
+CLUSTER_DOMAIN="$(/usr/local/bin/clusterinfo CLUSTER_DOMAIN)"
 API_VIP="$(dig +noall +answer "api.${CLUSTER_DOMAIN}" | awk '{print $NF}')"
 declare -r CONTAINER_NAME="api-haproxy"
 

--- a/assets/files/usr/local/bin/keepalived.sh
+++ b/assets/files/usr/local/bin/keepalived.sh
@@ -3,7 +3,7 @@ set -e
 
 mkdir --parents /etc/keepalived
 
-CLUSTER_DOMAIN="$(clusterinfo CLUSTER_DOMAIN)"
+CLUSTER_DOMAIN="$(/usr/local/bin/clusterinfo CLUSTER_DOMAIN)"
 API_VIP="$(dig +noall +answer "api.${CLUSTER_DOMAIN}" | awk '{print $NF}')"
 IFACE_CIDRS="$(ip addr show | grep -v "scope host" | grep -Po 'inet \K[\d.]+/[\d.]+' | xargs)"
 SUBNET_CIDR="$(/usr/local/bin/get_vip_subnet_cidr "$API_VIP" "$IFACE_CIDRS")"

--- a/assets/files/usr/local/bin/mdns-publisher.sh
+++ b/assets/files/usr/local/bin/mdns-publisher.sh
@@ -3,7 +3,7 @@ set -e
 
 mkdir --parents /etc/mdns
 
-CLUSTER_DOMAIN="$(clusterinfo CLUSTER_DOMAIN)"
+CLUSTER_DOMAIN="$(/usr/local/bin/clusterinfo CLUSTER_DOMAIN)"
 read -d '.' -a CLUSTER_ARR <<< $CLUSTER_DOMAIN
 CLUSTER_NAME=${CLUSTER_ARR[0]}
 API_VIP="$(dig +noall +answer "api.${CLUSTER_DOMAIN}" | awk '{print $NF}')"

--- a/assets/templates/99_master-api-haproxy.yaml
+++ b/assets/templates/99_master-api-haproxy.yaml
@@ -19,6 +19,7 @@ spec:
             ConditionPathExists=!/etc/pivot/image-pullspec
 
             [Service]
+            User=root
             WorkingDirectory=/etc/haproxy
             ExecStart=/usr/local/bin/haproxy.sh
             Restart=on-failure

--- a/assets/templates/99_master-coredns.yaml
+++ b/assets/templates/99_master-coredns.yaml
@@ -19,6 +19,7 @@ spec:
             ConditionPathExists=!/etc/pivot/image-pullspec
 
             [Service]
+            User=root
             WorkingDirectory=/etc/coredns
             ExecStartPre=/usr/local/bin/coredns.sh
             ExecStart=/usr/bin/podman start -a coredns

--- a/assets/templates/99_master-keepalived.yaml
+++ b/assets/templates/99_master-keepalived.yaml
@@ -19,6 +19,7 @@ spec:
             ConditionPathExists=!/etc/pivot/image-pullspec
 
             [Service]
+            User=root
             WorkingDirectory=/etc/keepalived
             ExecStartPre=/usr/local/bin/keepalived.sh
             ExecStart=/usr/bin/podman start -a keepalived

--- a/assets/templates/99_master-mdns-publisher.yaml
+++ b/assets/templates/99_master-mdns-publisher.yaml
@@ -19,6 +19,7 @@ spec:
             ConditionPathExists=!/etc/pivot/image-pullspec
 
             [Service]
+            User=root
             WorkingDirectory=/etc/mdns
             ExecStartPre=/usr/local/bin/mdns-publisher.sh
             ExecStart=/usr/bin/podman start -a mdns-publisher

--- a/assets/templates/99_worker-coredns.yaml
+++ b/assets/templates/99_worker-coredns.yaml
@@ -19,6 +19,7 @@ spec:
             ConditionPathExists=!/etc/pivot/image-pullspec
 
             [Service]
+            User=root
             WorkingDirectory=/etc/coredns
             ExecStartPre=/usr/local/bin/coredns.sh
             ExecStart=/usr/bin/podman start -a coredns

--- a/assets/templates/99_worker-mdns-publisher.yaml
+++ b/assets/templates/99_worker-mdns-publisher.yaml
@@ -19,6 +19,7 @@ spec:
             ConditionPathExists=!/etc/pivot/image-pullspec
 
             [Service]
+            User=root
             WorkingDirectory=/etc/mdns
             ExecStartPre=/usr/local/bin/mdns-publisher.sh
             ExecStart=/usr/bin/podman start -a mdns-publisher


### PR DESCRIPTION
Without the user being specified the podman containers failed to start.
Additionally, it is better to use the full path to /usr/local/bin in
case there's variations in PATH.