### PR TITLE
Don't labels as workers - this confuses MCD

### DIFF
--- a/06_create_cluster.sh
+++ b/06_create_cluster.sh
@@ -56,7 +56,6 @@ sudo virsh net-dhcp-leases baremetal
 
 # disable NoSchedule taints for masters until we have workers deployed
 oc adm taint nodes -l node-role.kubernetes.io/master node-role.kubernetes.io/master:NoSchedule-
-oc label node -l node-role.kubernetes.io/master node-role.kubernetes.io/worker=''
 
 #Verify Ingress controller functionality
 echo "Verifying Ingress controller functionality, first we'll check that router pod responsive"


### PR DESCRIPTION
Master is master and worker is worker, and never the twain shall meet.

This seems to confuse MCD and when `worker` label is found it attempts to reconfigure masters as workers in-flight. See https://github.com/openshift/machine-config-operator/pull/575