### PR TITLE
Use `upi finish` subcommand

### DIFF
--- a/06_create_cluster.sh
+++ b/06_create_cluster.sh
@@ -58,11 +58,5 @@ sudo virsh net-dhcp-leases baremetal
 oc adm taint nodes -l node-role.kubernetes.io/master node-role.kubernetes.io/master:NoSchedule-
 oc label node -l node-role.kubernetes.io/master node-role.kubernetes.io/worker=''
 
-#Verify Ingress controller functionality
-echo "Verifying Ingress controller functionality, first we'll check that router pod responsive"
-until curl -o /dev/null -kLs --fail  tst.apps.${CLUSTER_DOMAIN}:1936/healthz; do sleep 20 && echo "Router pod not responding"; done
-echo "Router pod responding, checking connectivity to console via ingress controller"
-until wget --no-check-certificate https://console-openshift-console.apps.${CLUSTER_DOMAIN}; do sleep 10 && echo "rechecking"; done
-echo "Ingress controller is working!"
-
+wait_for_cvo_finish ocp
 echo "Cluster up, you can interact with it via oc --config ${KUBECONFIG} <command>"

--- a/06_create_cluster.sh
+++ b/06_create_cluster.sh
@@ -32,8 +32,6 @@ fi
 export OS_TOKEN=fake-token
 export OS_URL=http://localhost:6385/
 
-trap collect_info_on_failure TERM
-
 wait_for_json ironic \
     "${OS_URL}/v1/nodes" \
     10 \

--- a/utils.sh
+++ b/utils.sh
@@ -30,6 +30,13 @@ function create_cluster() {
     $GOPATH/src/github.com/openshift-metalkube/kni-installer/bin/kni-install --dir "${assets_dir}" --log-level=debug create cluster
 }
 
+function wait_for_cvo_finish() {
+    local assets_dir
+
+    assets_dir="$1"
+    $GOPATH/src/github.com/openshift-metalkube/kni-installer/bin/kni-install --dir "${assets_dir}" --log-level=debug upi finish
+}
+
 function wait_for_json() {
     local name
     local url

--- a/utils.sh
+++ b/utils.sh
@@ -91,14 +91,6 @@ function master_node_val() {
     jq -r ".nodes[${n}].${val}" $MASTER_NODES_FILE
 }
 
-function collect_info_on_failure() {
-    $SSH -o ConnectionAttempts=500 core@$IP sudo journalctl -b -u bootkube
-    oc get clusterversion/version
-    oc get clusteroperators
-    oc get pods --all-namespaces | grep -v Running | grep -v Completed
-}
-
-
 function master_node_to_install_config() {
     local master_idx
     master_idx="$1"
@@ -151,13 +143,6 @@ function master_node_to_install_config() {
         deploy_kernel:  "${deploy_kernel}"
         deploy_ramdisk: "${deploy_ramdisk}"
 EOF
-}
-
-function collect_info_on_failure() {
-    $SSH -o ConnectionAttempts=500 core@$IP sudo journalctl -b -u bootkube
-    oc get clusterversion/version
-    oc get clusteroperators
-    oc get pods --all-namespaces | grep -v Running | grep -v Completed
 }
 
 function patch_ep_host_etcd() {


### PR DESCRIPTION
This would use kni-installer's subcommand which waits for all operators to rollout.

Requires #262 to make image-registry rollout properly