### PR TITLE
Clean-ups after move to kni-installer for masters

### DIFF
--- a/01_install_requirements.sh
+++ b/01_install_requirements.sh
@@ -100,14 +100,6 @@ if [ ! -f ${oc_tools_dir}/${oc_tools_local_file} ]; then
   sudo cp oc /usr/local/bin/
 fi
 
-# Install terraform
-if [ ! -f /usr/local/bin/terraform ]; then
-    curl -O https://releases.hashicorp.com/terraform/0.11.11/terraform_0.11.11_linux_amd64.zip
-    unzip terraform_0.11.11_linux_amd64.zip
-    sudo install terraform /usr/local/bin
-    rm -f terraform_0.11.11_linux_amd64.zip terraform
-fi
-
 # Generate user ssh key
 if [ ! -f $HOME/.ssh/id_rsa.pub ]; then
     ssh-keygen -f ~/.ssh/id_rsa -P ""

--- a/03_ocp_repo_sync.sh
+++ b/03_ocp_repo_sync.sh
@@ -33,8 +33,6 @@ function sync_go_repo_and_patch {
 
 sync_go_repo_and_patch github.com/openshift-metalkube/kni-installer https://github.com/openshift-metalkube/kni-installer.git
 
-sync_go_repo_and_patch github.com/openshift-metalkube/terraform-provider-ironic https://github.com/openshift-metalkube/terraform-provider-ironic.git
-
 sync_go_repo_and_patch github.com/openshift-metalkube/facet https://github.com/openshift-metalkube/facet.git
 
 # Build facet

--- a/run_ci.sh
+++ b/run_ci.sh
@@ -73,7 +73,7 @@ if [ -d "/home/notstack/metalkube-ironic-inspector" ] ; then
 fi
 
 # If directories for go projects exist, copy them to where go expects them
-for PROJ in facet kni-installer terraform-provider-ironic ; do
+for PROJ in facet kni-installer ; do
     [ ! -d /home/notstack/$PROJ ] && continue
 
     # Set origin so that sync_go_repo_and_patch is rebasing against the correct source

--- a/utils.sh
+++ b/utils.sh
@@ -19,6 +19,9 @@ function create_cluster() {
 
     assets_dir="$1"
 
+    # Enable terraform debug logging
+    export TF_LOG=DEBUG
+
     cp ${assets_dir}/install-config.yaml{,.tmp}
     $GOPATH/src/github.com/openshift-metalkube/kni-installer/bin/kni-install --dir "${assets_dir}" --log-level=debug create manifests
 


### PR DESCRIPTION
Because the provider is now vendored in the installer, we don't need
to sync it or deal with the terraform-provider-ironic repo in any direct
way. CI testing only needs to happen when the provider gets updated in
kni-installer.

This also enable debug logging for terraform.