### PR TITLE
Remove ostest-bootstrap vm

### DIFF
--- a/host_cleanup.sh
+++ b/host_cleanup.sh
@@ -32,3 +32,7 @@ sudo virsh net-destroy baremetal
 sudo virsh net-undefine baremetal
 sudo virsh net-destroy provisioning
 sudo virsh net-undefine provisioning
+for vm in `sudo virsh list --name|grep "ostest-.*-bootstrap"`; do
+    sudo virsh destroy $vm
+    sudo virsh undefine $vm
+done


### PR DESCRIPTION
Seems like the cleanup leaves the bootstrap VM.
This patch will ensure the vms are removed.

Signed-off-by: Alexander Chuzhoy <achuzhoy@redhat.com>