### PR TITLE
fix missing cluster_domain in keepalived rendering

### DIFF
--- a/assets/files/etc/kubernetes/manifests/coredns.yaml
+++ b/assets/files/etc/kubernetes/manifests/coredns.yaml
@@ -16,15 +16,22 @@ spec:
   - name: kubeconfig
     hostPath:
       path: "/etc/kubernetes/kubeconfig"
-  - name: oc
-    hostPath:
-      path: "/bin/oc"
-  - name: clusterinfo
-    hostPath:
-      path: "/usr/local/bin/clusterinfo"
   - name: conf-dir
     empty-dir: {}
   initContainers:
+  - name: clusterrc-generation
+    image: quay.io/openshift-metalkube/kubeconfig-extractor:latest
+    command:
+    - "/usr/bin/kubeconfig-extractor"
+    args:
+    - "/etc/kubernetes/kubeconfig"
+    - "/etc/kubernetes/static-pod-resources/clusterrc"
+    resources: {}
+    volumeMounts:
+    - name: resource-dir
+      mountPath: "/etc/kubernetes/static-pod-resources"
+    - name: kubeconfig
+      mountPath: "/etc/kubernetes/kubeconfig"
   - name: render-corefile
     image: quay.io/openshift/origin-node:latest
     command:
@@ -32,13 +39,11 @@ spec:
     - "-c"
     - |
       #/bin/bash
-      set -e
+      set -ex
 
-      CLUSTER_DOMAIN="$(/usr/local/bin/clusterinfo DOMAIN)"
-      CLUSTER_NAME="$(/usr/local/bin/clusterinfo NAME)"
-
-      export CLUSTER_DOMAIN
-      export CLUSTER_NAME
+      source /etc/kubernetes/static-pod-resources/clusterrc
+      export DOMAIN
+      export NAME
       /usr/libexec/platform-python -c "from __future__ import print_function
       import os
       with open('/etc/kubernetes/static-pod-resources/Corefile.template', 'r') as f:
@@ -54,12 +59,6 @@ spec:
       mountPath: "/etc/kubernetes/static-pod-resources"
     - name: conf-dir
       mountPath: "/etc/coredns"
-    - name: kubeconfig
-      mountPath: "/etc/kubernetes/kubeconfig"
-    - name: oc
-      mountPath: "/bin/oc"
-    - name: clusterinfo
-      mountPath: "/usr/local/bin/clusterinfo"
     imagePullPolicy: IfNotPresent
   containers:
   - name: coredns

--- a/assets/files/etc/kubernetes/manifests/keepalived.yaml
+++ b/assets/files/etc/kubernetes/manifests/keepalived.yaml
@@ -16,18 +16,25 @@ spec:
   - name: kubeconfig
     hostPath:
       path: "/etc/kubernetes/kubeconfig"
-  - name: oc
-    hostPath:
-      path: "/bin/oc"
-  - name: clusterinfo
-    hostPath:
-      path: "/usr/local/bin/clusterinfo"
   - name: get-vip-subnet-cidr
     hostPath:
       path: "/usr/local/bin/get_vip_subnet_cidr"
   - name: conf-dir
     empty-dir: {}
   initContainers:
+  - name: clusterrc-generation
+    image: quay.io/openshift-metalkube/kubeconfig-extractor:latest
+    command:
+    - "/usr/bin/kubeconfig-extractor"
+    args:
+    - "/etc/kubernetes/kubeconfig"
+    - "/etc/kubernetes/static-pod-resources/clusterrc"
+    resources: {}
+    volumeMounts:
+    - name: resource-dir
+      mountPath: "/etc/kubernetes/static-pod-resources"
+    - name: kubeconfig
+      mountPath: "/etc/kubernetes/kubeconfig"
   - name: render-keepalived-conf
     image: quay.io/openshift/origin-node:latest
     command:
@@ -35,17 +42,17 @@ spec:
     - "-c"
     - |
       #/bin/bash
-      set -e
+      set -ex
 
-      CLUSTER_DOMAIN="$(/usr/local/bin/clusterinfo DOMAIN)"
-      API_VIP="$(dig +noall +answer "api.${CLUSTER_DOMAIN}" | awk '{print $NF}')"
+      source /etc/kubernetes/static-pod-resources/clusterrc
+      API_VIP="$(dig +noall +answer "api.${DOMAIN}" | awk '{print $NF}')"
       IFACE_CIDRS="$(ip addr show | grep -v "scope host" | grep -Po 'inet \K[\d.]+/[\d.]+' | xargs)"
       SUBNET_CIDR="$(/usr/local/bin/get_vip_subnet_cidr "$API_VIP" "$IFACE_CIDRS")"
       INTERFACE="$(ip -o addr show to "$SUBNET_CIDR" | awk '{print $2}')"
-      DNS_VIP="$(dig +noall +answer "ns1.${CLUSTER_DOMAIN}" | awk '{print $NF}')"
-      INGRESS_VIP="$(dig +noall +answer "test.apps.${CLUSTER_DOMAIN}" | awk '{print $NF}')"
+      DNS_VIP="$(dig +noall +answer "ns1.${DOMAIN}" | awk '{print $NF}')"
+      INGRESS_VIP="$(dig +noall +answer "test.apps.${DOMAIN}" | awk '{print $NF}')"
 
-      export CLUSTER_DOMAIN
+      export DOMAIN
       export INTERFACE
       export API_VIP
       export DNS_VIP
@@ -63,12 +70,6 @@ spec:
       mountPath: "/etc/kubernetes/static-pod-resources"
     - name: conf-dir
       mountPath: "/etc/keepalived"
-    - name: kubeconfig
-      mountPath: "/etc/kubernetes/kubeconfig"
-    - name: oc
-      mountPath: "/bin/oc"
-    - name: clusterinfo
-      mountPath: "/usr/local/bin/clusterinfo"
     - name: get-vip-subnet-cidr
       mountPath: "/usr/local/bin/get_vip_subnet_cidr"
     imagePullPolicy: IfNotPresent

--- a/assets/files/etc/kubernetes/manifests/keepalived.yaml
+++ b/assets/files/etc/kubernetes/manifests/keepalived.yaml
@@ -45,9 +45,10 @@ spec:
       DNS_VIP="$(dig +noall +answer "ns1.${CLUSTER_DOMAIN}" | awk '{print $NF}')"
       INGRESS_VIP="$(dig +noall +answer "test.apps.${CLUSTER_DOMAIN}" | awk '{print $NF}')"
 
+      export CLUSTER_DOMAIN
+      export INTERFACE
       export API_VIP
       export DNS_VIP
-      export INTERFACE
       export INGRESS_VIP
       /usr/libexec/platform-python -c "from __future__ import print_function
       import os

--- a/assets/files/etc/kubernetes/manifests/mdns-publisher.yaml
+++ b/assets/files/etc/kubernetes/manifests/mdns-publisher.yaml
@@ -16,18 +16,25 @@ spec:
   - name: kubeconfig
     hostPath:
       path: "/etc/kubernetes/kubeconfig"
-  - name: oc
-    hostPath:
-      path: "/bin/oc"
-  - name: clusterinfo
-    hostPath:
-      path: "/usr/local/bin/clusterinfo"
   - name: get-vip-subnet-cidr
     hostPath:
       path: "/usr/local/bin/get_vip_subnet_cidr"
   - name: conf-dir
     empty-dir: {}
   initContainers:
+  - name: clusterrc-generation
+    image: quay.io/openshift-metalkube/kubeconfig-extractor:latest
+    command:
+    - "/usr/bin/kubeconfig-extractor"
+    args:
+    - "/etc/kubernetes/kubeconfig"
+    - "/etc/kubernetes/static-pod-resources/clusterrc"
+    resources: {}
+    volumeMounts:
+    - name: resource-dir
+      mountPath: "/etc/kubernetes/static-pod-resources"
+    - name: kubeconfig
+      mountPath: "/etc/kubernetes/kubeconfig"
   - name: render-config
     image: quay.io/openshift/origin-node:latest
     command:
@@ -35,14 +42,15 @@ spec:
     - "-c"
     - |
       #/bin/bash
-      set -e
-      CLUSTER_DOMAIN="$(/usr/local/bin/clusterinfo DOMAIN)"
-      CLUSTER_NAME="$(/usr/local/bin/clusterinfo NAME)"
-      API_VIP="$(dig +noall +answer "api.${CLUSTER_DOMAIN}" | awk '{print $NF}')"
+      set -ex
+
+      source /etc/kubernetes/static-pod-resources/clusterrc
+      CLUSTER_NAME="$NAME"
+      API_VIP="$(dig +noall +answer "api.${DOMAIN}" | awk '{print $NF}')"
       IFACE_CIDRS="$(ip addr show | grep -v "scope host" | grep -Po 'inet \K[\d.]+/[\d.]+' | xargs)"
       SUBNET_CIDR="$(/usr/local/bin/get_vip_subnet_cidr "$API_VIP" "$IFACE_CIDRS")"
       PREFIX="${SUBNET_CIDR#*/}"
-      DNS_VIP="$(dig +noall +answer "ns1.${CLUSTER_DOMAIN}" | awk '{print $NF}')"
+      DNS_VIP="$(dig +noall +answer "ns1.${DOMAIN}" | awk '{print $NF}')"
       ONE_CIDR="$(ip addr show to "$SUBNET_CIDR" | \
                   grep -Po 'inet \K[\d.]+/[\d.]+' | \
                   grep -v "${DNS_VIP}/$PREFIX" | \
@@ -55,6 +63,7 @@ spec:
       export MASTER_HOSTNAME
       export ETCD_HOSTNAME
       export NON_VIRTUAL_IP
+      export DOMAIN
       export CLUSTER_NAME
       /usr/libexec/platform-python -c "from __future__ import print_function
       import os
@@ -68,12 +77,6 @@ spec:
       mountPath: "/etc/kubernetes/static-pod-resources"
     - name: conf-dir
       mountPath: "/etc/mdns"
-    - name: kubeconfig
-      mountPath: "/etc/kubernetes/kubeconfig"
-    - name: oc
-      mountPath: "/bin/oc"
-    - name: clusterinfo
-      mountPath: "/usr/local/bin/clusterinfo"
     - name: get-vip-subnet-cidr
       mountPath: "/usr/local/bin/get_vip_subnet_cidr"
     imagePullPolicy: IfNotPresent

--- a/assets/files/etc/kubernetes/static-pod-resources/coredns/Corefile.template
+++ b/assets/files/etc/kubernetes/static-pod-resources/coredns/Corefile.template
@@ -1,7 +1,7 @@
 . {
     errors
     health
-    mdns $CLUSTER_DOMAIN 3 $CLUSTER_NAME
+    mdns $DOMAIN 3 $NAME
     forward . /etc/coredns/resolv.conf
     cache 30
     reload

--- a/assets/files/etc/kubernetes/static-pod-resources/keepalived/keepalived.conf.template
+++ b/assets/files/etc/kubernetes/static-pod-resources/keepalived/keepalived.conf.template
@@ -5,7 +5,7 @@ vrrp_script chk_ocp {
 }
 
 vrrp_script chk_dns {
-    script "host -t SRV _etcd-server-ssl._tcp.${CLUSTER_DOMAIN} localhost"
+    script "host -t SRV _etcd-server-ssl._tcp.${DOMAIN} localhost"
     interval 1
     weight 50
 }


### PR DESCRIPTION
When moved to static pods, we also moved the dns health check to happen
in the keepalived conf instead of a separate script. The issue was that
even though it needs CLUSTER_DOMAIN, we were not exporting it before
using python to expand the keepalived.conf template.

Fixes #320