### PR TITLE
launch bmo after installing its crd

### DIFF
--- a/08_deploy_bmo.sh
+++ b/08_deploy_bmo.sh
@@ -17,5 +17,5 @@ sed -i 's/namespace: .*/namespace: openshift-machine-api/g' ocp/deploy/role_bind
 oc --config ocp/auth/kubeconfig apply -f ocp/deploy/service_account.yaml --namespace=openshift-machine-api
 oc --config ocp/auth/kubeconfig apply -f ocp/deploy/role.yaml --namespace=openshift-machine-api
 oc --config ocp/auth/kubeconfig apply -f ocp/deploy/role_binding.yaml
-oc --config ocp/auth/kubeconfig apply -f ocp/deploy/operator.yaml --namespace=openshift-machine-api
 oc --config ocp/auth/kubeconfig apply -f ocp/deploy/crds/metalkube_v1alpha1_baremetalhost_crd.yaml
+oc --config ocp/auth/kubeconfig apply -f ocp/deploy/operator.yaml --namespace=openshift-machine-api


### PR DESCRIPTION
The operator won't work until the CRD is installed, so switch the
order of the two calls.