### PR TITLE
disable haproxy service until it is a static pod

### DIFF
--- a/assets/templates/99_master-api-haproxy.yaml
+++ b/assets/templates/99_master-api-haproxy.yaml
@@ -27,7 +27,7 @@ spec:
             [Install]
             WantedBy=multi-user.target
 
-          enabled: true
+          enabled: false
           name: api-haproxy.service
     storage:
       files:


### PR DESCRIPTION
Right now api-haproxy still is implemented as a systemd+podman piece of
infra. The problem is that when the podman pod storage breaks (as
happened with the other infra pods), the API ceases to be reachable.

Let's disable it until I reimplement it as a static pod.