### PR TITLE
'upi finish' has been renamed to ''wait-for cluster-ready'

### DIFF
--- a/utils.sh
+++ b/utils.sh
@@ -37,7 +37,7 @@ function wait_for_cvo_finish() {
     local assets_dir
 
     assets_dir="$1"
-    $GOPATH/src/github.com/openshift-metalkube/kni-installer/bin/kni-install --dir "${assets_dir}" --log-level=debug upi finish
+    $GOPATH/src/github.com/openshift-metalkube/kni-installer/bin/kni-install --dir "${assets_dir}" --log-level=debug wait-for cluster-ready
 }
 
 function wait_for_json() {


### PR DESCRIPTION
With the latest rebase (https://github.com/openshift-metalkube/kni-installer/pull/42), upi has been renamed to wait-for