### PR TITLE
add a script to register hosts

### DIFF
--- a/11_register_hosts.sh
+++ b/11_register_hosts.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/bash
+
+set -ex
+
+source common.sh
+eval "$(go env)"
+
+# Get the latest bits for baremetal-operator
+export BMOPATH="$GOPATH/src/github.com/metalkube/baremetal-operator"
+
+function list_masters() {
+    cat $MASTER_NODES_FILE | \
+        jq '.nodes[] | {
+           name,
+           driver,
+           address:.driver_info.ipmi_address,
+           port:.driver_info.ipmi_port,
+           user:.driver_info.ipmi_username,
+           password:.driver_info.ipmi_password,
+           mac: .ports[0].address
+           } |
+           .name + " " +
+           .driver + "://" + .address + ":" + .port + " " +
+           .user + " " + .password + " " + .mac' \
+        | sed 's/"//g'
+}
+
+# Register the masters linked to their respective Machine objects.
+function make_bm_masters() {
+    while read name address user password mac; do
+        go run $SCRIPTDIR/make-bm-worker/main.go \
+           -address "$address" \
+           -password "$password" \
+           -user "$user" \
+           -machine-namespace openshift-machine-api \
+           -machine  "$(echo $name | sed 's/openshift/ostest/')" \
+           -boot-mac "$mac" \
+           "$name"
+    done
+}
+
+function list_workers() {
+    # Includes -machine and -machine-namespace
+    cat $NODES_FILE | \
+        jq '.nodes[] | select(.name | contains("worker")) | {
+           name,
+           driver,
+           address:.driver_info.ipmi_address,
+           port:.driver_info.ipmi_port,
+           user:.driver_info.ipmi_username,
+           password:.driver_info.ipmi_password,
+           mac: .ports[0].address
+           } |
+           .name + " " +
+           .driver + "://" + .address + ":" + .port + " " +
+           .user + " " + .password + " " + .mac' \
+       | sed 's/"//g'
+}
+
+# Register the workers without a machine reference so they are
+# available for provisioning.
+function make_bm_workers() {
+    # Does not include -machine or -machine-namespace
+    while read name address user password mac; do
+        go run $SCRIPTDIR/make-bm-worker/main.go \
+           -address "$address" \
+           -password "$password" \
+           -user "$user" \
+           -boot-mac "$mac" \
+           "$name"
+    done
+}
+
+list_masters | make_bm_masters | tee $SCRIPTDIR/ocp/master_crs.yaml
+
+list_workers | make_bm_workers | tee $SCRIPTDIR/ocp/worker_crs.yaml
+
+oc --config ocp/auth/kubeconfig apply -f $SCRIPTDIR/ocp/master_crs.yaml --namespace=openshift-machine-api
+
+oc --config ocp/auth/kubeconfig apply -f $SCRIPTDIR/ocp/worker_crs.yaml --namespace=openshift-machine-api

--- a/make-bm-worker/main.go
+++ b/make-bm-worker/main.go
@@ -34,25 +34,35 @@ spec:
   bmc:
     address: {{ .BMCAddress }}
     credentialsName: {{ .Name }}-bmc-secret
-{{- if .WithImage }}
+{{- if .MAC }}
+  bootMACAddress: {{ .MAC }}
+{{ end -}}{{- if .WithImage }}
   userData:
     namespace: openshift-machine-api
     name: worker-user-data
   image:
     url: "{{ .ImageSourceURL }}"
     checksum: "{{ .Checksum }}"
-{{ end -}}
+{{ end -}}{{ if .WithMachine }}
+  machineRef:
+    name: {{ .Machine }}
+    namespace: {{ .MachineNamespace }}
+{{ end }}
 `
 
 // TemplateArgs holds the arguments to pass to the template.
 type TemplateArgs struct {
-	Name            string
-	BMCAddress      string
-	EncodedUsername string
-	EncodedPassword string
-	WithImage       bool
-	Checksum        string
-	ImageSourceURL  string
+	Name             string
+	BMCAddress       string
+	MAC              string
+	EncodedUsername  string
+	EncodedPassword  string
+	WithImage        bool
+	Checksum         string
+	ImageSourceURL   string
+	WithMachine      bool
+	Machine          string
+	MachineNamespace string
 }
 
 func encodeToSecret(input string) string {
@@ -65,6 +75,12 @@ func main() {
 	var bmcAddress = flag.String("address", "", "address URL for BMC")
 	var verbose = flag.Bool("v", false, "turn on verbose output")
 	var withImage = flag.Bool("image", false, "include the image settings to trigger deployment")
+	var machine = flag.String(
+		"machine", "", "specify name of a related, existing, machine to link")
+	var machineNamespace = flag.String(
+		"machine-namespace", "", "specify namespace of a related, existing, machine to link")
+	var bootMAC = flag.String(
+		"boot-mac", "", "specify boot MAC address of host")
 
 	flag.Parse()
 
@@ -87,13 +103,19 @@ func main() {
 	}
 
 	args := TemplateArgs{
-		Name:            strings.Replace(hostName, "_", "-", -1),
-		BMCAddress:      *bmcAddress,
-		EncodedUsername: encodeToSecret(*username),
-		EncodedPassword: encodeToSecret(*password),
-		WithImage:       *withImage,
-		Checksum:        instanceImageChecksumURL,
-		ImageSourceURL:  instanceImageSource,
+		Name:             strings.Replace(hostName, "_", "-", -1),
+		BMCAddress:       *bmcAddress,
+		MAC:              *bootMAC,
+		EncodedUsername:  encodeToSecret(*username),
+		EncodedPassword:  encodeToSecret(*password),
+		WithImage:        *withImage,
+		Checksum:         instanceImageChecksumURL,
+		ImageSourceURL:   instanceImageSource,
+		Machine:          strings.TrimSpace(*machine),
+		MachineNamespace: strings.TrimSpace(*machineNamespace),
+	}
+	if args.Machine != "" {
+		args.WithMachine = true
 	}
 	if *verbose {
 		fmt.Fprintf(os.Stderr, "%v", args)


### PR DESCRIPTION
Add an optional step 11 to register hosts for the masters and workers.

Masters are registered with a machine reference, to prevent them from
showing up as available to be provisioned.

Workers are registered without a machine reference, so they are
available to be provisioned.

Add the missing machine and boot-mac arguments to make-bm-workers.