### PR TITLE
Add sanity check when getting VIP for nameserver

### DIFF
--- a/assets/files/etc/NetworkManager/dispatcher.d/pre-up.d/dns-vip-prepender
+++ b/assets/files/etc/NetworkManager/dispatcher.d/pre-up.d/dns-vip-prepender
@@ -6,9 +6,12 @@ STATUS=$2
 case "$STATUS" in
     pre-up)
     logger -s "NM dns-vip-prepender triggered by pre-upping ${1}."
-    set -e
     CLUSTER_DOMAIN="$(/usr/local/bin/clusterinfo DOMAIN)"
-    DNS_VIP="$(dig +noall +answer "ns1.${CLUSTER_DOMAIN}" | awk '{print $NF}')"
+    if ! HOST_QUERY="$(host ns1.${CLUSTER_DOMAIN})" ; then
+        logger -s "NM dns-vip-prepender: nameserver could not be resolved, exiting"
+        exit 0
+    fi
+    DNS_VIP=$(echo "${HOST_QUERY}" | awk '{print $NF}')
     set +e
     if [[ -n $DNS_VIP ]]; then
         logger -s "NM dns-vip-prepender: Checking if DNS VIP is the first entry in resolv.conf"


### PR DESCRIPTION
Initially when the system is started, resolv.conf has some dummy resolv.conf
coming from the tree. When dns-vip-prepender is called the first time, it tries
to use that buggy nameserver and captures the error code of the dig command,
causing to set an incorrect nameserver. This patch changes dig for host, to
better capture error codes, and don't perform any action on resolv.conf if
nameserver cannot be resolved properly.