### PR TITLE
Make VM node specs configurable and bump defaults

### DIFF
--- a/02_configure_host.sh
+++ b/02_configure_host.sh
@@ -11,12 +11,13 @@ source ocp_install_env.sh
 # Note we copy the playbook so the roles/modules from tripleo-quickstart
 # are found without a special ansible.cfg
 export ANSIBLE_LIBRARY=./library
+export VM_NODES_FILE=${VM_NODES_FILE:-tripleo-quickstart-config/metalkube-nodes.yml}
 
 ANSIBLE_FORCE_COLOR=true ansible-playbook \
     -e "non_root_user=$USER" \
     -e "working_dir=$WORKING_DIR" \
     -e "roles_path=$PWD/roles" \
-    -e @tripleo-quickstart-config/metalkube-nodes.yml \
+    -e @${VM_NODES_FILE} \
     -e "local_working_dir=$HOME/.quickstart" \
     -e "virthost=$HOSTNAME" \
     -e "platform=$NODES_PLATFORM" \

--- a/tripleo-quickstart-config/metalkube-nodes.yml
+++ b/tripleo-quickstart-config/metalkube-nodes.yml
@@ -1,4 +1,4 @@
-default_memory: 8192
+default_memory: 16384
 default_vcpu: 4
 overcloud_nodes:
   - name: openshift_master_0
@@ -17,25 +17,17 @@ overcloud_nodes:
     flavor: openshift_worker
     virtualbmc_port: 6233
 
-  - name: openshift_worker_1
-    flavor: openshift_worker
-    virtualbmc_port: 6234
-
-  - name: openshift_worker_2
-    flavor: openshift_worker
-    virtualbmc_port: 6235
-
-node_count: 6
+node_count: 4
 
 flavors:
   openshift_master:
     memory: '{{openshift_master_memory|default(default_memory)}}'
     disk: '{{openshift_master_disk|default(default_disk)}}'
     vcpu: '{{openshift_master_vcpu|default(default_vcpu)}}'
-    extradisks: true
+    extradisks: false
 
   openshift_worker:
     memory: '{{openshift_worker_memory|default(default_memory)}}'
     disk: '{{openshift_worker_disk|default(default_disk)}}'
     vcpu: '{{openshift_worker_vcpu|default(default_vcpu)}}'
-    extradisks: true
+    extradisks: false


### PR DESCRIPTION
Add a VM_NODES_FILE variable, so that you can copy and modify
the metalkube-nodes.yml ansible vars file if desired (e.g to add
extra memory, or test with more/less nodes)

e.g

cp tripleo-quickstart-config/metalkube-nodes.yml ~
vim ~/metalkube-nodes.yml
echo "export VM_NODES_FILE=\"/home/$USER/metalkube-nodes.yml\"" >> config_$USER.sh

Proceed with caution if modifying this file, as the most well tested path
is using the defaults.