### PR TITLE
Support additional root device hints

### DIFF
--- a/common.sh
+++ b/common.sh
@@ -34,7 +34,7 @@ MANAGE_INT_BRIDGE=${MANAGE_INT_BRIDGE:-y}
 # Internal interface, to bridge virbr0
 INT_IF=${INT_IF:-}
 #Root disk to deploy coreOS - use /dev/sda on BM
-ROOT_DISK=${ROOT_DISK:="/dev/sda"}
+ROOT_DISK_NAME=${ROOT_DISK_NAME-"/dev/sda"}
 # Kafka Strimzi configs
 KAFKA_NAMESPACE=${KAFKA_NAMESPACE:-strimzi}
 KAFKA_CLUSTERNAME=${KAFKA_CLUSTERNAME:-strimzi}

--- a/utils.sh
+++ b/utils.sh
@@ -153,10 +153,18 @@ EOF
       root_devices:
 EOF
 
+    [ -n "$ROOT_DISK" ] && ROOT_DISK_NAME="$ROOT_DISK"
+    for _hint in ${!ROOT_DISK_*}; do
+        [ -z "${!_hint}" ] && continue
+        hint_name=${_hint/#ROOT_DISK_/}
+        hint_name=${hint_name,,}
+        hint_value=${!_hint}
+    done
+
     for ((master_idx=0;master_idx<$1;master_idx++)); do
       cat <<EOF
         openshift-master-$master_idx:
-          name: "${ROOT_DISK}"
+          $hint_name: "${hint_value}"
 EOF
     done
 


### PR DESCRIPTION
Using "name" isn't reliable on baremetal as device
name can swap from one deploy to anopther, causing
boot failures as the image gets written to the wronge
drive.

To use another root device hint in place of "name"
a deploy can set
export ROOT_DISK_NAME=
export ROOT_DISK_HCTL=0:0:0:0