### PR TITLE
Pass -image option in make_bm_workers function

### DIFF
--- a/11_register_hosts.sh
+++ b/11_register_hosts.sh
@@ -67,6 +67,7 @@ function make_bm_workers() {
            -password "$password" \
            -user "$user" \
            -boot-mac "$mac" \
+           -image \
            "$name"
     done
 }


### PR DESCRIPTION
Without the image option the worker nodes seem to not end up in provisioning state and they boot of the disk instead of nic.