### PR TITLE
Modifying Rook Installation & Adding Storage Monitoring Components

### DIFF
--- a/03_ocp_repo_sync.sh
+++ b/03_ocp_repo_sync.sh
@@ -63,6 +63,9 @@ sync_go_repo_and_patch github.com/metalkube/baremetal-operator https://github.co
 # Install rook repository
 sync_go_repo_and_patch github.com/rook/rook https://github.com/rook/rook.git
 
+# Install ceph-mixin repository
+sync_go_repo_and_patch github.com/ceph/ceph-mixins https://github.com/ceph/ceph-mixins.git
+
 # Install Kafka Strimzi repository
 sync_go_repo_and_patch github.com/strimzi/strimzi-kafka-operator https://github.com/strimzi/strimzi-kafka-operator.git
 

--- a/10_deploy_rook.sh
+++ b/10_deploy_rook.sh
@@ -7,27 +7,42 @@ source common.sh
 figlet "Deploying rook" | lolcat
 eval "$(go env)"
 
+export MIXINPATH="$GOPATH/src/github.com/ceph/ceph-mixins"
 export ROOKPATH="$GOPATH/src/github.com/rook/rook"
 cd $ROOKPATH/cluster/examples/kubernetes/ceph
-oc create -f common.yaml
+
+sed 's/name: rook-ceph$/name: openshift-storage/' common.yaml > common-modified.yaml
+sed -i 's/namespace: rook-ceph/namespace: openshift-storage/' common-modified.yaml
+oc create -f common-modified.yaml
+oc label namespace openshift-storage  "openshift.io/cluster-monitoring=true"
+oc policy add-role-to-user view system:serviceaccount:openshift-monitoring:prometheus-k8s -n openshift-storage
+
 sed '/FLEXVOLUME_DIR_PATH/!b;n;c\          value: "\/etc/kubernetes\/kubelet-plugins\/volume\/exec"' operator-openshift.yaml > operator-openshift-modified.yaml
 sed -i 's/# - name: FLEXVOLUME_DIR_PATH/- name: FLEXVOLUME_DIR_PATH/' operator-openshift-modified.yaml
+sed -i 's/namespace: rook-ceph/namespace: openshift-storage/' operator-openshift-modified.yaml
+sed -i 's/:rook-ceph:/:openshift-storage:/' operator-openshift-modified.yaml
 oc create -f operator-openshift-modified.yaml
 sleep 120
-oc wait --for condition=ready  pod -l app=rook-ceph-operator -n rook-ceph --timeout=120s
-oc wait --for condition=ready  pod -l app=rook-ceph-agent -n rook-ceph --timeout=120s
-oc wait --for condition=ready  pod -l app=rook-discover -n rook-ceph --timeout=120s
+
+oc wait --for condition=ready  pod -l app=rook-ceph-operator -n openshift-storage --timeout=120s
+oc wait --for condition=ready  pod -l app=rook-ceph-agent -n openshift-storage --timeout=120s
+oc wait --for condition=ready  pod -l app=rook-discover -n openshift-storage --timeout=120s
+
 sed "s/useAllDevices: .*/useAllDevices: true/" cluster.yaml > cluster-modified.yaml
 sed -i 's/# port: 8443/port: 8444/' cluster-modified.yaml
+sed -i 's/namespace: rook-ceph/namespace: openshift-storage/' cluster-modified.yaml
 oc create -f cluster-modified.yaml
-oc create -f toolbox.yaml
 sleep 120
+
+sed 's/namespace: rook-ceph/namespace: openshift-storage/' toolbox.yaml > toolbox-modified.yaml
+oc create -f toolbox-modified.yaml
+
 cat <<EOF | oc create -f -
 apiVersion: ceph.rook.io/v1
 kind: CephBlockPool
 metadata:
   name: rbd
-  namespace: rook-ceph
+  namespace: openshift-storage
 spec:
   failureDomain: osd
   replicated:
@@ -44,7 +59,7 @@ metadata:
 provisioner: ceph.rook.io/block
 parameters:
   blockPool: rbd
-  clusterNamespace: rook-ceph
+  clusterNamespace: openshift-storage
   fstype: xfs
 reclaimPolicy: Retain
 EOF
@@ -54,7 +69,7 @@ apiVersion: ceph.rook.io/v1
 kind: CephFilesystem
 metadata:
   name: myfs
-  namespace: rook-ceph
+  namespace: openshift-storage
 spec:
   metadataPool:
     replicated:
@@ -66,3 +81,11 @@ spec:
     activeCount: 1
     activeStandby: true
 EOF
+
+cd $ROOKPATH/cluster/examples/kubernetes/ceph/monitoring
+sed 's/namespace: rook-ceph/namespace: openshift-storage/' service-monitor.yaml > service-monitor-modified.yaml
+sed -i 's/- rook-ceph/- openshift-storage/' service-monitor-modified.yaml
+oc create -f service-monitor-modified.yaml
+
+cd $MIXINPATH/manifests
+oc create -f prometheus-rules.yaml

--- a/10_deploy_rook.sh
+++ b/10_deploy_rook.sh
@@ -7,6 +7,7 @@ source common.sh
 figlet "Deploying rook" | lolcat
 eval "$(go env)"
 
+CEPH_VERSION=v14
 export MIXINPATH="$GOPATH/src/github.com/ceph/ceph-mixins"
 export ROOKPATH="$GOPATH/src/github.com/rook/rook"
 cd $ROOKPATH/cluster/examples/kubernetes/ceph
@@ -17,9 +18,7 @@ oc create -f common-modified.yaml
 oc label namespace openshift-storage  "openshift.io/cluster-monitoring=true"
 oc policy add-role-to-user view system:serviceaccount:openshift-monitoring:prometheus-k8s -n openshift-storage
 
-sed '/FLEXVOLUME_DIR_PATH/!b;n;c\          value: "\/etc/kubernetes\/kubelet-plugins\/volume\/exec"' operator-openshift.yaml > operator-openshift-modified.yaml
-sed -i 's/# - name: FLEXVOLUME_DIR_PATH/- name: FLEXVOLUME_DIR_PATH/' operator-openshift-modified.yaml
-sed -i 's/namespace: rook-ceph/namespace: openshift-storage/' operator-openshift-modified.yaml
+sed 's/namespace: rook-ceph/namespace: openshift-storage/' operator-openshift.yaml > operator-openshift-modified.yaml
 sed -i 's/:rook-ceph:/:openshift-storage:/' operator-openshift-modified.yaml
 oc create -f operator-openshift-modified.yaml
 sleep 120
@@ -31,6 +30,8 @@ oc wait --for condition=ready  pod -l app=rook-discover -n openshift-storage --t
 sed "s/useAllDevices: .*/useAllDevices: true/" cluster.yaml > cluster-modified.yaml
 sed -i 's/# port: 8443/port: 8444/' cluster-modified.yaml
 sed -i 's/namespace: rook-ceph/namespace: openshift-storage/' cluster-modified.yaml
+sed -i 's/allowUnsupported: false/allowUnsupported: true/' cluster-modified.yaml
+sed -i 's/image: ceph\/ceph.*/image: ceph\/ceph:$CEPH_VERSION/' cluster-modified.yaml
 oc create -f cluster-modified.yaml
 sleep 120
 
@@ -85,6 +86,7 @@ EOF
 cd $ROOKPATH/cluster/examples/kubernetes/ceph/monitoring
 sed 's/namespace: rook-ceph/namespace: openshift-storage/' service-monitor.yaml > service-monitor-modified.yaml
 sed -i 's/- rook-ceph/- openshift-storage/' service-monitor-modified.yaml
+sed -i 's/rook_cluster: rook-ceph/rook_cluster: openshift-storage/' service-monitor-modified.yaml
 oc create -f service-monitor-modified.yaml
 
 cd $MIXINPATH/manifests


### PR DESCRIPTION
For the Storage Console and Prometheus based Monitoring to work on top of OCP, there are few restrictions that needs to be addressed. This PR addresses those and adds Storage Monitoring feature to the stack.

Changes: 
1. Rook + Ceph cluster is installed in the openshift-storage namespace.
2. Service Monitor is added to openshift-storage namespace.
3. Prometheus Rule file is applied from the ceph-mixins project to enable alerting.

Signed-off-by: Umanga Chapagain <chapagainumanga@gmail.com>