### PR TITLE
Specify master and worker counts in install-config.

### DIFF
--- a/ocp_install_env.sh
+++ b/ocp_install_env.sh
@@ -19,10 +19,16 @@ function generate_ocp_install_config() {
     outdir="$1"
 
     cat > "${outdir}/install-config.yaml" << EOF
-apiVersion: v1beta3
+apiVersion: v1beta4
 baseDomain: ${BASE_DOMAIN}
 metadata:
   name: ${CLUSTER_NAME}
+compute:
+- name: worker
+  replicas: 1
+controlPlane:
+  name: master
+  replicas: 3
 platform:
   baremetal:
     nodes:


### PR DESCRIPTION
We now only create 1 worker VM, so specify the number of workers as 1
instead of the default of 3.