### PR TITLE
Switch to pinned release of OpenShift

### DIFF
--- a/01_install_requirements.sh
+++ b/01_install_requirements.sh
@@ -89,13 +89,13 @@ sudo pip install \
   yq
 
 # Install oc client
-oc_version=4.0.22
+oc_version=4.1
 oc_tools_dir=$HOME/oc-${oc_version}
 oc_tools_local_file=openshift-client-${oc_version}.tar.gz
 if [ ! -f ${oc_tools_dir}/${oc_tools_local_file} ]; then
   mkdir -p ${oc_tools_dir}
   cd ${oc_tools_dir}
-  wget https://mirror.openshift.com/pub/openshift-v3/clients/${oc_version}/linux/oc.tar.gz -O ${oc_tools_local_file}
+  wget https://mirror.openshift.com/pub/openshift-v4/clients/oc/${oc_version}/linux/oc.tar.gz -O ${oc_tools_local_file}
   tar xvzf ${oc_tools_local_file}
   sudo cp oc /usr/local/bin/
 fi

--- a/06_create_cluster.sh
+++ b/06_create_cluster.sh
@@ -7,6 +7,14 @@ source utils.sh
 source common.sh
 source ocp_install_env.sh
 
+# Do some PULL_SECRET sanity checking
+if [[ "${OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE}" == *"registry.svc.ci.openshift.org"* ]]; then
+    if [[ "${PULL_SECRET}" != *"registry.svc.ci.openshift.org"* ]]; then
+        echo "Please get a valid pull secret for registry.svc.ci.openshift.org."
+        exit 1
+    fi
+fi
+
 if [ ! -d ocp ]; then
     mkdir -p ocp
 

--- a/ocp_install_env.sh
+++ b/ocp_install_env.sh
@@ -10,8 +10,13 @@ export EXTERNAL_SUBNET="192.168.111.0/24"
 # Not used by the installer.  Used by s.sh.
 export SSH_PRIV_KEY="$HOME/.ssh/id_rsa"
 
-# Temporary workaround pending merge of https://github.com/openshift/machine-api-operator/pull/246
-export OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE="registry.svc.ci.openshift.org/openshift/origin-release:v4.0"
+#
+# See https://origin-release.svc.ci.openshift.org/ for release details
+#
+# The release we default to here is pinned and known to work with our current
+# version of kni-installer.
+#
+export OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE="registry.svc.ci.openshift.org/ocp/release:4.0.0-0.ci-2019-04-17-133604"
 
 function generate_ocp_install_config() {
     local outdir

--- a/utils.sh
+++ b/utils.sh
@@ -42,7 +42,7 @@ function wait_for_cvo_finish() {
     local assets_dir
 
     assets_dir="$1"
-    $GOPATH/src/github.com/openshift-metalkube/kni-installer/bin/kni-install --dir "${assets_dir}" --log-level=debug wait-for cluster-ready
+    $GOPATH/src/github.com/openshift-metalkube/kni-installer/bin/kni-install --dir "${assets_dir}" --log-level=debug wait-for install-complete
 }
 
 function wait_for_json() {


### PR DESCRIPTION
See: https://github.com/openshift/installer/pull/1622

This can be dropped once kni-installer includes the above change.

The previous v4.0 tag we were using stopped getting updates, so this change is the equivalent of what we were using before.  Note that v4.0 and v4.1 don't have major functional differences other than the week or so of time since v4.0 got updated.  They're both still chasing master at the moment.