### PR TITLE
handle missing ipmi port

### DIFF
--- a/11_register_hosts.sh
+++ b/11_register_hosts.sh
@@ -20,7 +20,7 @@ function list_masters() {
            mac: .ports[0].address
            } |
            .name + " " +
-           .driver + "://" + .address + ":" + .port + " " +
+           .driver + "://" + .address + (if .port then ":" + .port else "" end) + " " +
            .user + " " + .password + " " + .mac' \
         | sed 's/"//g'
 }
@@ -52,7 +52,7 @@ function list_workers() {
            mac: .ports[0].address
            } |
            .name + " " +
-           .driver + "://" + .address + ":" + .port + " " +
+           .driver + "://" + .address + (if .port then ":" + .port else "" end)  + " " +
            .user + " " + .password + " " + .mac' \
        | sed 's/"//g'
 }


### PR DESCRIPTION
For IPMI systems where the port is the default, don't force the user
to specify one.

Fixes #345