### PR TITLE
Fix issue creating FILESTOCACHE in run_ci.sh

### DIFF
--- a/run_ci.sh
+++ b/run_ci.sh
@@ -27,8 +27,8 @@ export CONFIG=/opt/data/config_notstack.sh
 # Install moreutils for ts
 sudo yum install -y epel-release
 sudo yum install -y moreutils
-# Install jq for common.sh
-sudo yum install -y jq
+# Install jq and golang for common.sh
+sudo yum install -y jq golang
 sudo yum remove -y epel-release
 
 source common.sh


### PR DESCRIPTION
This fixes an issue introduced via https://github.com/openshift-metalkube/dev-scripts/pull/359

Because `run_ci.sh` sources common.sh before running `01_install_requirements.sh` we have to install golang or we fail to source the GOPATH that's needed to get the latest version.

That does also raise the issue of whether we should calculate this after running `03_ocp_repo_sync.sh` but this seems to unblock CI for now