### PR TITLE
update KubeVirt CDI version

### DIFF
--- a/manifests/8_cnv_cdi_operator.yaml
+++ b/manifests/8_cnv_cdi_operator.yaml
@@ -56,7 +56,7 @@ spec:
       serviceAccountName: cdi-operator
       containers:
         - name: cdi-operator
-          image: kubevirt/cdi-operator:v1.6.0
+          image: kubevirt/cdi-operator:v1.8.0
           ports:
           - containerPort: 60000
             name: metrics
@@ -67,7 +67,7 @@ spec:
           - name: DOCKER_REPO
             value: kubevirt
           - name: DOCKER_TAG
-            value: v1.6.0
+            value: v1.8.0
           - name: CONTROLLER_IMAGE
             value: cdi-controller
           - name: IMPORTER_IMAGE


### PR DESCRIPTION
1.8 is intended to be the stable release for the demo.  Also, 1.6 has a pretty bad bug causing the controller to crash.