### PR TITLE
Workaround to avoid the affect of the undeleted routes for API, DNS and INGRESS VIPs

### DIFF
--- a/assets/files/etc/kubernetes/manifests/keepalived.yaml
+++ b/assets/files/etc/kubernetes/manifests/keepalived.yaml
@@ -52,6 +52,7 @@ spec:
       API_VIP="$(dig +noall +answer "api.${DOMAIN}" | awk '{print $NF}')"
       IFACE_CIDRS="$(ip addr show | grep -v "scope host" | grep -Po 'inet \K[\d.]+/[\d.]+' | xargs)"
       SUBNET_CIDR="$(/usr/local/bin/get_vip_subnet_cidr "$API_VIP" "$IFACE_CIDRS")"
+      NET_MASK="$(echo $SUBNET_CIDR | cut -d "/" -f 2)"
       INTERFACE="$(ip -o addr show to "$SUBNET_CIDR" | awk '{print $2}')"
       DNS_VIP="$(dig +noall +answer "ns1.${DOMAIN}" | awk '{print $NF}')"
       INGRESS_VIP="$(dig +noall +answer "test.apps.${DOMAIN}" | awk '{print $NF}')"
@@ -70,6 +71,7 @@ spec:
       export API_VRID
       export DNS_VRID
       export INGRESS_VRID
+      export NET_MASK
       /usr/libexec/platform-python -c "from __future__ import print_function
       import os
       with open('/etc/kubernetes/static-pod-resources/keepalived.conf.template', 'r') as f:

--- a/assets/files/etc/kubernetes/static-pod-resources/keepalived/keepalived.conf.template
+++ b/assets/files/etc/kubernetes/static-pod-resources/keepalived/keepalived.conf.template
@@ -27,7 +27,7 @@ vrrp_instance ${CLUSTER_NAME}_API {
         auth_pass ${CLUSTER_NAME}_api_vip
     }
     virtual_ipaddress {
-        ${API_VIP}
+        ${API_VIP}/${NET_MASK}
     }
     track_script {
         chk_ocp
@@ -45,7 +45,7 @@ vrrp_instance ${CLUSTER_NAME}_DNS {
         auth_pass ${CLUSTER_NAME}_dns_vip
     }
     virtual_ipaddress {
-        ${DNS_VIP}
+        ${DNS_VIP}/${NET_MASK}
     }
     track_script {
         chk_dns
@@ -63,7 +63,7 @@ vrrp_instance ${CLUSTER_NAME}_INGRESS {
         auth_pass cluster_uuid_ingress_vip
     }
     virtual_ipaddress {
-        ${INGRESS_VIP}
+        ${INGRESS_VIP}/${NET_MASK}
     }
     track_script {
         chk_ingress


### PR DESCRIPTION
This is a temporary solution to workaround the extra host route, 
It changes VIPs netmask to the master subnet netmask.

I set it as [WIP] since I didn't test it yet.