### PR TITLE
Reference correct domain env var

### DIFF
--- a/assets/files/etc/kubernetes/manifests/coredns.yaml
+++ b/assets/files/etc/kubernetes/manifests/coredns.yaml
@@ -51,7 +51,7 @@ spec:
       with open('/etc/coredns/Corefile', 'w') as dest:
           print(os.path.expandvars(content), file=dest)"
 
-      DNS_VIP="$(dig +noall +answer "ns1.${CLUSTER_DOMAIN}" | awk '{print $NF}')"
+      DNS_VIP="$(dig +noall +answer "ns1.${DOMAIN}" | awk '{print $NF}')"
       grep -v "${DNS_VIP}" /etc/resolv.conf | tee /etc/coredns/resolv.conf
     resources: {}
     volumeMounts:


### PR DESCRIPTION
CLUSTER_DOMAIN was removed in 8474c871f3904c11d76ca1ac65997a5c4a3c29a5
but this reference wasn't updated. As a result, we've been querying
for "ns1." when starting coredns. This seems to work fine in my
virt environment, but I just debugged a system where that was
resulting in an empty DNS_VIP. This caused coredns to crash if it
tried to forward a query because there was nothing in resolv.conf.
The grep -v "" removed all lines, not just the one we wanted.