### PR TITLE
Lower SRV record limit to 2

### DIFF
--- a/assets/files/etc/kubernetes/static-pod-resources/coredns/Corefile.template
+++ b/assets/files/etc/kubernetes/static-pod-resources/coredns/Corefile.template
@@ -1,7 +1,7 @@
 . {
     errors
     health
-    mdns $DOMAIN 3 $NAME
+    mdns $DOMAIN 2 $NAME
     forward . /etc/coredns/resolv.conf
     cache 30
     reload


### PR DESCRIPTION
We added this to prevent individual etcd nodes from clustering with
only themselves, but etcd can cluster correctly with only 2 nodes.