### PR TITLE
Add missing config option to oc scale commands

### DIFF
--- a/08_deploy_bmo.sh
+++ b/08_deploy_bmo.sh
@@ -21,10 +21,10 @@ oc --config ocp/auth/kubeconfig apply -f ocp/deploy/crds/metalkube_v1alpha1_bare
 oc --config ocp/auth/kubeconfig apply -f ocp/deploy/operator.yaml --namespace=openshift-machine-api
 
 # Workaround for https://github.com/metalkube/cluster-api-provider-baremetal/issues/57
-oc scale deployment -n openshift-machine-api machine-api-controllers --replicas=0
-while [ ! $(oc get deployment -n openshift-machine-api machine-api-controllers -o json | jq .spec.replicas) ]
+oc --config ocp/auth/kubeconfig scale deployment -n openshift-machine-api machine-api-controllers --replicas=0
+while [ ! $(oc --config ocp/auth/kubeconfig get deployment -n openshift-machine-api machine-api-controllers -o json | jq .spec.replicas) ]
 do
   echo "Scaling down machine-api-controllers ..."
 done
 echo "Scaling up machine-api-controllers ..."
-oc scale deployment -n openshift-machine-api machine-api-controllers --replicas=1
+oc --config ocp/auth/kubeconfig scale deployment -n openshift-machine-api machine-api-controllers --replicas=1


### PR DESCRIPTION
Currently scale commands fail:

```shell
00:51:31         "2019-04-18 00:51:30 | + oc scale deployment -n openshift-machine-api machine-api-controllers --replicas=0", 
00:51:31         "2019-04-18 00:51:30 | error: Missing or incomplete configuration info.  Please login or point to an existing, complete config file:", 
00:51:31         "2019-04-18 00:51:30 | ", 
00:51:31         "2019-04-18 00:51:30 |   1. Via the command-line flag --config", 
00:51:31         "2019-04-18 00:51:30 |   2. Via the KUBECONFIG environment variable", 
00:51:31         "2019-04-18 00:51:30 |   3. In your home directory as ~/.kube/config", 
00:51:31         "2019-04-18 00:51:30 | ", 
00:51:31         "2019-04-18 00:51:30 | To view or setup config directly use the 'config' command."
```