### PR TITLE
Fix automatic deployment of libvirt workers.

### DIFF
--- a/11_register_hosts.sh
+++ b/11_register_hosts.sh
@@ -8,6 +8,10 @@ eval "$(go env)"
 # Get the latest bits for baremetal-operator
 export BMOPATH="$GOPATH/src/github.com/metalkube/baremetal-operator"
 
+if [ "${NODES_PLATFORM}" = "libvirt" ] ; then
+    HW_PROFILE="-hwprofile libvirt"
+fi
+
 function list_masters() {
     cat $MASTER_NODES_FILE | \
         jq '.nodes[] | {
@@ -34,7 +38,7 @@ function make_bm_masters() {
            -user "$user" \
            -machine-namespace openshift-machine-api \
            -machine  "$(echo $name | sed 's/openshift/ostest/')" \
-           -boot-mac "$mac" \
+           -boot-mac "$mac" ${HW_PROFILE} \
            "$name"
     done
 }
@@ -66,7 +70,7 @@ function make_bm_workers() {
            -address "$address" \
            -password "$password" \
            -user "$user" \
-           -boot-mac "$mac" \
+           -boot-mac "$mac" ${HW_PROFILE} \
            "$name"
     done
 }

--- a/make-bm-worker/main.go
+++ b/make-bm-worker/main.go
@@ -43,10 +43,12 @@ spec:
   image:
     url: "{{ .ImageSourceURL }}"
     checksum: "{{ .Checksum }}"
-{{ end -}}{{ if .WithMachine }}
+{{ end -}}{{- if .WithMachine }}
   machineRef:
     name: {{ .Machine }}
     namespace: {{ .MachineNamespace }}
+{{ end -}}{{- if .WithHWProfile }}
+  hardwareProfile: {{ .HardwareProfile }}
 {{ end }}
 `
 
@@ -63,6 +65,8 @@ type TemplateArgs struct {
 	WithMachine      bool
 	Machine          string
 	MachineNamespace string
+	WithHWProfile    bool
+	HardwareProfile  string
 }
 
 func encodeToSecret(input string) string {
@@ -81,6 +85,7 @@ func main() {
 		"machine-namespace", "", "specify namespace of a related, existing, machine to link")
 	var bootMAC = flag.String(
 		"boot-mac", "", "specify boot MAC address of host")
+	var hardwareProfile = flag.String("hwprofile", "", "Specify a hardware profile")
 
 	flag.Parse()
 
@@ -113,9 +118,13 @@ func main() {
 		ImageSourceURL:   instanceImageSource,
 		Machine:          strings.TrimSpace(*machine),
 		MachineNamespace: strings.TrimSpace(*machineNamespace),
+		HardwareProfile:  strings.TrimSpace(*hardwareProfile),
 	}
 	if args.Machine != "" {
 		args.WithMachine = true
+	}
+	if args.HardwareProfile != "" {
+		args.WithHWProfile = true
 	}
 	if *verbose {
 		fmt.Fprintf(os.Stderr, "%v", args)


### PR DESCRIPTION
The following change recently went in to the baremetal-operator:

https://github.com/metalkube/baremetal-operator/commit/abed6b3e8381e410244b082fd54bf9569b66c3eb

With that change, I needed the baremetal-operator to use the "libvirt"
hardware profile for vbmc based workers.  This patch explicitly sets
that when using a virtual env.

The baremetal-operator also would have done this if the bmc address
had a "libvirt://" prefix, but we're registering them with an
"ipmi://" prefix here, even for virt, which works other than this.