### PR TITLE
Switch to using virtio-scsi for VM disks

### DIFF
--- a/common.sh
+++ b/common.sh
@@ -34,7 +34,7 @@ MANAGE_INT_BRIDGE=${MANAGE_INT_BRIDGE:-y}
 # Internal interface, to bridge virbr0
 INT_IF=${INT_IF:-}
 #Root disk to deploy coreOS - use /dev/sda on BM
-ROOT_DISK=${ROOT_DISK:="/dev/vda"}
+ROOT_DISK=${ROOT_DISK:="/dev/sda"}
 # Kafka Strimzi configs
 KAFKA_NAMESPACE=${KAFKA_NAMESPACE:-strimzi}
 KAFKA_CLUSTERNAME=${KAFKA_CLUSTERNAME:-strimzi}

--- a/tripleo-quickstart-config/roles/libvirt/defaults/main.yml
+++ b/tripleo-quickstart-config/roles/libvirt/defaults/main.yml
@@ -20,8 +20,8 @@ images:
 # `environment/setup` role).
 libvirt_volume_pool: oooq_pool
 libvirt_domain_type: kvm
-libvirt_diskdev: vda
-libvirt_diskbus: virtio
+libvirt_diskdev: sda
+libvirt_diskbus: scsi
 libvirt_arch: x86_64
 libvirt_cpu_mode: host-model
 

--- a/tripleo-quickstart-config/roles/libvirt/setup/overcloud/templates/baremetalvm.xml.j2
+++ b/tripleo-quickstart-config/roles/libvirt/setup/overcloud/templates/baremetalvm.xml.j2
@@ -26,6 +26,9 @@
       <source pool='{{ libvirt_volume_pool }}' volume='{{ item.name }}.qcow2'/>
       <target dev='{{ libvirt_diskdev }}' bus='{{ libvirt_diskbus }}'/>
     </disk>
+{% if libvirt_diskbus == 'scsi' %}
+  <controller type='scsi' model='virtio-scsi' />
+{% endif %}
 {% for network in networks %}
     <interface type='bridge'>
       <mac address='{{ node_mac_map.get(item.name).get(network.name) }}'/>


### PR DESCRIPTION
Avoid disk naming differences between VM and baremetal by using virtio-scsi devices.