### PR TITLE
add a separate script for linking machine and node

### DIFF
--- a/add-machine-ips.sh
+++ b/add-machine-ips.sh
@@ -19,9 +19,7 @@ for node in $(oc --config ocp/auth/kubeconfig get nodes -o template --template='
     if [[ "$machine_name" == *"worker"* ]]; then
         machine_name=$(oc --config ocp/auth/kubeconfig get machines -n openshift-machine-api | grep $node_name | cut -f1 -d' ')
     fi
-    uid=$(echo $node | cut -f1 -d':')
-    addresses=$(oc --config ocp/auth/kubeconfig get node $node_name -o json | jq -c '.status.addresses')
-    curl -X PATCH http://localhost:8001/apis/machine.openshift.io/v1beta1/namespaces/openshift-machine-api/machines/$machine_name/status -H "Content-type: application/merge-patch+json" -d '{"status":{"addresses":'"${addresses}"',"nodeRef":{"kind":"Node","name":"'"${node_name}"'","uid":"'"${uid}"'"}}}'
+    $SCRIPTDIR/link-machine-and-node.sh "$node" "$machine_name"
 done
 
 kill $proxy_pid

--- a/link-machine-and-node.sh
+++ b/link-machine-and-node.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+set -x
+set -e
+
+machine="$1"
+node="$2"
+
+if [ -z "$machine" -o -z "$node" ]; then
+    echo "Usage: $0 MACHINE NODE"
+    exit 1
+fi
+
+uid=$(echo $node | cut -f1 -d':')
+node_name=$(echo $node | cut -f2 -d':')
+
+addresses=$(oc --config ocp/auth/kubeconfig get node ${node_name} -o json | jq -c '.status.addresses')
+
+curl -X PATCH \
+     http://localhost:8001/apis/machine.openshift.io/v1beta1/namespaces/openshift-machine-api/machines/$machine_name/status \
+     -H "Content-type: application/merge-patch+json" \
+     -d '{"status":{"addresses":'"${addresses}"',"nodeRef":{"kind":"Node","name":"'"${node_name}"'","uid":"'"${uid}"'"}}}'


### PR DESCRIPTION
Retain add-machine-ips.sh but add another script that just takes the
machine and node names so in baremetal environments where the naming
conventions do not hold we can link them explicitly.