### PR TITLE
Increase the worker wait timeout

### DIFF
--- a/11_register_hosts.sh
+++ b/11_register_hosts.sh
@@ -87,7 +87,7 @@ wait_for_worker() {
     echo "Waiting for worker $worker to appear ..."
     while [ "$(oc get nodes | grep $worker)" = "" ]; do sleep 5; done
     echo "$worker registered, waiting for Ready condition ..."
-    oc wait node/$worker --for=condition=Ready
+    oc wait node/$worker --for=condition=Ready --timeout=90s
 }
 
 wait_for_worker worker-0


### PR DESCRIPTION
The default worker wait timeout of 30s isn't sufficient while waiting for the node
to shut down, power cycle, and come back up before joining the cluster, particularly
in virtual environments where there are CPU, disk, or memory contensions.  Increase
the timeout to something more accommodating.